### PR TITLE
Tdf hg38

### DIFF
--- a/configs/config_hg38.json
+++ b/configs/config_hg38.json
@@ -75,7 +75,7 @@
         },
        "generate_tdf":
         {
-            "tdfgen": "/seqstore/webfolders/IGVTools/igvtools.jar"
+            "tdfgen": "/apps/bio/dependencies/wgs_somatic/IGVTools/IGV_2.10.3"
         },
         "canvas":
         {

--- a/configs/config_hg38.json
+++ b/configs/config_hg38.json
@@ -75,7 +75,7 @@
         },
        "generate_tdf":
         {
-            "tdfgen": "/apps/bio/dependencies/wgs_somatic/IGVTools/IGV_2.10.3"
+            "tdfgen": "/seqstore/webfolders/IGVTools/igvtools.jar" 
         },
         "canvas":
         {

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -260,7 +260,7 @@ def analysis_main(args, runnormal, runtumor, output, normalname, normalfastqs, t
     if os.path.isfile(f"{output}/reporting/workflow_finished.txt"):
         # these functions are only executed if snakemake workflow has finished successfully
         yearly_stats(args.tumorsample, args.normalsample)
-        petagene_compress_bam(args.outputdir, args.tumorsample)
+        #petagene_compress_bam(args.outputdir, args.tumorsample)
 
 
 if __name__ == '__main__':

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -260,7 +260,7 @@ def analysis_main(args, runnormal, runtumor, output, normalname, normalfastqs, t
     if os.path.isfile(f"{output}/reporting/workflow_finished.txt"):
         # these functions are only executed if snakemake workflow has finished successfully
         yearly_stats(args.tumorsample, args.normalsample)
-        #petagene_compress_bam(args.outputdir, args.tumorsample)
+        petagene_compress_bam(args.outputdir, args.tumorsample)
 
 
 if __name__ == '__main__':

--- a/pipeline.snakefile
+++ b/pipeline.snakefile
@@ -143,6 +143,8 @@ if reference == "hg38":
     include:    "workflows/rules/variantcalling/manta_hg38.smk"
     # Coverage
     include:    "workflows/rules/qc/coverage_hg38.smk"
+    # Generate tdf
+    include:    "workflows/rules/mapping/generate_tdf_hg38.smk"
 else:
     ###########################################################
     # HG19 rules
@@ -153,6 +155,8 @@ else:
     include:        "workflows/rules/variantcalling/manta.smk"
     # Coverage
     include:        "workflows/rules/qc/coverage.smk"
+    # Generate tdf
+    include:    "workflows/rules/mapping/generate_tdf.smk"
 
 def get_igv_input(wildcards):
     if igvuser:

--- a/pipeline.snakefile
+++ b/pipeline.snakefile
@@ -112,7 +112,7 @@ include:        "workflows/tn_workflow.smk"
 
 ########################################
 # Mapping
-include:        "workflows/rules/mapping/generate_tdf.smk"
+#include:        "workflows/rules/mapping/generate_tdf.smk"
 
 #########################################
 # VariantCalling

--- a/workflows/rules/mapping/generate_tdf_hg38.smk
+++ b/workflows/rules/mapping/generate_tdf_hg38.smk
@@ -5,9 +5,8 @@ rule generate_tdf_hg38:
     input:
         "{workingdir}/{stype}/realign/{sname}_REALIGNED.bam"
     params:
-        #igvjar = pipeconfig["rules"]["generate_tdf"]["tdfgen"]
-        igv = pipeconfig["rules"]["generate_tdf"]["tdfgen"]
+        igvjar = pipeconfig["rules"]["generate_tdf"]["tdfgen"]
     output:
         "{workingdir}/{stype}/reports/{sname}_REALIGNED.bam.tdf"
     run:
-        shell("nohup java -Xmx32768m --module-path={params.igv}/lib @{params.igv}/igv.args --module=org.igv/org.broad.igv.tools.IgvTools count {input} {output} hg38")
+        shell("nohup java -Xmx32768m -jar {params.igvjar} count {input} {output} hg38")

--- a/workflows/rules/mapping/generate_tdf_hg38.smk
+++ b/workflows/rules/mapping/generate_tdf_hg38.smk
@@ -1,0 +1,13 @@
+# vim: syntax=python tabstop=4 expandtab
+# coding: utf-8
+
+rule generate_tdf_hg38:
+    input:
+        "{workingdir}/{stype}/realign/{sname}_REALIGNED.bam"
+    params:
+        #igvjar = pipeconfig["rules"]["generate_tdf"]["tdfgen"]
+        igv = pipeconfig["rules"]["generate_tdf"]["tdfgen"]
+    output:
+        "{workingdir}/{stype}/reports/{sname}_REALIGNED.bam.tdf"
+    run:
+        shell("nohup java -Xmx32768m --module-path={params.igv}/lib @{params.igv}/igv.args --module=org.igv/org.broad.igv.tools.IgvTools count {input} {output} hg38")


### PR DESCRIPTION
Rule generate_tdf only used hg19 as reference genome before. Have now added so it uses hg38 for samples run with hg38 flag. 