### PR TITLE
Clean code

### DIFF
--- a/tools/slims.py
+++ b/tools/slims.py
@@ -132,7 +132,7 @@ def link_fastqs(list_of_fq_paths):
         # Now symlinks all additional paths to fastqs for tumor and normal in other runs. If I symlink to demultiplexdir of particular run instead, all fastqs belonging to the T/N pair will be in the same folder and the pipeline can start using that folder as argument.
             os.symlink(fq_path, os.path.join(f"/home/xshang/ws_testoutput/symlinks/", os.path.basename(fq_path)))
 
-def find_more_fastqs(sample_name, run_tag):
+def find_more_fastqs(sample_name, run_tag, logger):
     """
     If a sample name has fastqs from additional sequencing runs - fetch those fastq objects and link them to Demultiplexdir of current run. 
     """
@@ -149,10 +149,10 @@ def find_more_fastqs(sample_name, run_tag):
             fqSSample = SlimsSample(sample_name, tag)
             json_info = json.loads(fqSSample.fastq.cntn_cstm_demuxerSampleResult.value)
             fq_paths = json_info['fastq_paths']
-            print(f'linking fastqs for {sample_name}_{tag}')
+            logger.info(f'linking fastqs for {sample_name}_{tag}')
             link_fastqs(fq_paths)
 
-def get_pair_dict(Sctx, run_tag):
+def get_pair_dict(Sctx, run_tag, logger):
     """
     If tumor and normal are sequenced in different runs - find the pairs. 
     Then use the find_more_fastqs function to find paths of fastqs that are sequenced in different runs and link fastqs.
@@ -171,7 +171,7 @@ def get_pair_dict(Sctx, run_tag):
         pair.slims_info = translate_slims_info(pair)
         pair_dict[pair.slims_info["content_id"]] = [pair.slims_info["tumorNormalType"], pair.slims_info["tumorNormalID"]]
         # Check if there are additional fastqs in other runs and symlink fastqs
-        find_more_fastqs(pair.cntn_id.value, run_tag)
+        find_more_fastqs(pair.cntn_id.value, run_tag, logger)
     return pair_dict
 
 

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -14,7 +14,7 @@ import traceback
 from definitions import CONFIG_PATH, ROOT_DIR, ROOT_LOGGING_PATH
 from context import RunContext, SampleContext
 from helpers import setup_logger
-from tools.slims import get_sample_slims_info, SlimsSample, run_paths_for_more_fastqs, get_pair_and_run_paths
+from tools.slims import get_sample_slims_info, SlimsSample, find_more_fastqs, get_pair_dict
 
 logger = setup_logger('wrapper', os.path.join(ROOT_LOGGING_PATH, 'WS_wrapper.log'))
 
@@ -75,45 +75,9 @@ def generate_context_objects(Rctx):
 
     return Rctx
 
-"""
-def link_fastqs(list_of_fq_paths):
-    '''Link fastqs to fastq-folder in demultiplexdir of current run. Need to change the hardcoded path to my home... '''
-    # TODO: using a hardcoded test folder right now for symlinks. will change this to correct Demultiplexdir/current-run/fastq folder.
-    # TODO: additional fastqs need to still be in demultiplexdir. not considering downloading from hcp right now. need to consider this later...
-    for fq_path in list_of_fq_paths:
-    # Only links if link doesn't already exist
-        if not os.path.islink(os.path.join(f"/home/xshang/ws_testoutput/symlinks/", os.path.basename(fq_path))):
-        # Now symlinks all additional paths to fastqs for tumor and normal in other runs. If I symlink to demultiplexdir of particular run instead, all fastqs belonging to the T/N pair will be in the same folder and the pipeline can start using that folder as argument.
-            os.symlink(fq_path, os.path.join(f"/home/xshang/ws_testoutput/symlinks/", os.path.basename(fq_path)))
-"""
-
-def get_samples_ready(list_of_samples, pair_ids_in_run, run_tag):
-    '''Add samples that belong to current run from current run and additional runs to list of ready samples'''
-    samples_ready = []
-    for s in list_of_samples:
-        # will have Sctx for all samples set for wgs-somatic in other runs that have samples that are related to current run. samples that are not related to current run shouldn't run again in wgs-somatic.
-        if not any(pair_id in pair_ids_in_run for pair_id in (s.sample_name.split("DNA")[1], s.slims_info["tumorNormalID"])):
-            logger.info(f'{s.sample_name} does not belong to current run')
-            continue
-        if s.sample_id.split('_',1)[1] == run_tag:
-            # the plan is to link the fastqs of other runs to fastq-folder in demultiplexdir for the current run so all fastqs for a sample + its pair are in the same folder. then the pipeline can start based on this folder.
-            logger.info(f'fastqs for {s.sample_id} do not need to be linked')
-        #else:
-            # only need to link fastqs from other runs since i will link them to fastq folder of current run.
-            #logger.info(f'linking fastqs for {s.sample_id}')
-            #link_fastqs(s.fastqs)
-        samples_ready.append(s)
-    return samples_ready
-
-
 def wrapper():
 
-    # using lists to keep track of stuff... could maybe be done in a better way...
-    #additional_run_paths = []
-    #tumor_samples = []
-    #normal_samples = []
-    pair_ids_in_run = []
-    started_samples = []
+    # Empty dict, will update later with T/N pair info
     pair_dict_all_pairs = {}
 
     with open(CONFIG_PATH, 'r') as conf:
@@ -152,45 +116,21 @@ def wrapper():
         # get Rctx and Sctx for current run
         Rctx_run = generate_context_objects(Rctx)
 
-
-        # Get run paths for samples (or other part of t/n pair) with additional fastqs in other runs
+        # Get T/N pair info in a dict for samples and link additional fastqs from other runs
         for sctx in Rctx_run.sample_contexts:
-            #run_paths = get_pair_and_run_paths(sctx, Rctx.run_tag)
-            #print(f'sctx slims info: {sctx.slims_info["content_id"]}, {sctx.slims_info["tumorNormalType"]}, {sctx.slims_info["tumorNormalID"]}')
-            pair_dict = get_pair_and_run_paths(sctx, Rctx.run_tag)
-            #print(f'pair dict hej {pair_dict}')
+            pair_dict = get_pair_dict(sctx, Rctx.run_tag)
             pair_dict_all_pairs.update(pair_dict)
-        #print(f'pair dict all pairs: {pair_dict_all_pairs}')
-            #if run_paths:
-                # removes that there is a list of lists and makes just one list and removes duplicates
-                #run_paths = list(set(list(chain.from_iterable(run_paths))))
-                #print(f'run paths: {run_paths}')
-                #for r in run_paths:
-                #    if r not in additional_run_paths:
-                #        additional_run_paths.append(r)
-    #print(f'additional run paths: {additional_run_paths}')
 
-    #print(f'pair dict all pairs: {pair_dict_all_pairs}')
+    # Uses the dictionary of T/N samples to put the correct pairs together and finds the correct input arguments to the pipeline
     for key in pair_dict_all_pairs:
-        #print(f'DICT: {pair_dict_all_pairs.get(key)}')
         if 'tumor' in pair_dict_all_pairs.get(key):
             t = key
-            t_ID = [val for val in pair_dict_all_pairs.get(key) if val != 'tumor'][0]
-            #t_ID.remove('tumor')
-            #ID = pair_dict_all_pairs.get(key).remove('tumor') 
-            #print(f't: {t}, t_ID: {t_ID}')
-            #tumor_samples.append(key)
+            t_ID = [val for val in pair_dict_all_pairs.get(key) if val != 'tumor'][0] # crappy solution... but works since there is only one item in the list
             for k in pair_dict_all_pairs:
-                #print(f'k: {k}')
-                #print(f'hejsan {pair_dict_all_pairs.get(k)}')
                 if 'normal' in pair_dict_all_pairs.get(k):
                     n = k
-                    #print(f'n: {n}')
                     n_ID = [val for val in pair_dict_all_pairs.get(k) if val != 'normal'][0]
-                    #print(f'n_ID: {n_ID}')
-                    #n_ID.remove('normal')
-                    if n_ID == t_ID or t_ID == n.split("DNA")[1] or n_ID == t.split("DNA")[1]:
-                        #print(f'{t} and {n} pair!')
+                    if n_ID == t_ID or t_ID == n.split("DNA")[1] or n_ID == t.split("DNA")[1]: # if we change to pair id instead of tumorNormalID this is needed
                         logger.info(f'Starting wgs_somatic with arguments: \n \
 runnormal: {Rctx_run.run_name} \n \
 runtumor: {Rctx_run.run_name} \n \
@@ -201,52 +141,6 @@ tumorfastqs: {os.path.join(Rctx_run.run_path, "fastq")} \n \
 outputdir: {os.path.join("/seqstore/webfolders/wgs/barncancer/hg38", t)} \n \
 igvuser: barncancer_hg38 \n \
 hg38ref: yes')
-
-    #print(f'tumor samples {tumor_samples}')
-    #print(f'normal samples {normal_samples}') 
-
-
-    # get Rctx and Sctx for additional runs that have samples related to current run
-    # i realized that i don't actually use "additionalRctx" for anything now. 
-    # but using the function generate_context_objects does append to sample_status which is used below... 
-    # could be done in a better way if i don't have to use additionalRctx anyway. 
-    # just appending to sample_status is neccessary.  
-
-    #for run_path in run_paths:
-    #    additionalRctx = RunContext(run_path)
-    #    additionalRctx = generate_context_objects(additionalRctx)
-
-
-    # FIXME Need to get pair ID in other way if i don't have Sctx for additional runs
-    # Could maybe make a dictionary of tumor:normal
-
-    # get tumor and normal samples related to current run from approved samples
-    #for Sctx in sample_status['approved']:
-    #    print(f'sample status approved sample id {Sctx.sample_id}')
-        #if Rctx_run.run_tag == Sctx.sample_id.split("_",1)[1]:
-            # use both tumorNormalID and sample name (minus "DNA") as pair ids since we will change pair ids to be normalname for tumor and tumorname for normal 
-        #pair_ids_in_run.append(Sctx.slims_info["tumorNormalID"])
-        #pair_ids_in_run.append(Sctx.sample_name.split("DNA")[1])
-        #if Sctx.slims_info['tumorNormalType'] == 'tumor':
-        #    tumor_samples.append(Sctx)
-        #elif Sctx.slims_info['tumorNormalType'] == 'normal':
-        #    normal_samples.append(Sctx)
-        #else:
-        #    logger.info(f'Warning! {Sctx.slims_info["content_id"]} is not set as tumor or normal.')
-    
-    # make list of unique pair ids in current run
-    #pair_ids_in_run = list(set(pair_ids_in_run))
-    #logger.info(f'pair IDs in run: {pair_ids_in_run}')
-
-
-
-    # find tumor/normal pairs in the run and start pipeline
-
-    # get lists of ready samples and remove duplicates from list
-    #tumor_samples_ready = list(set(get_samples_ready(tumor_samples, pair_ids_in_run, Rctx_run.run_tag)))
-    #normal_samples_ready = list(set(get_samples_ready(normal_samples, pair_ids_in_run, Rctx_run.run_tag)))
-    #print(f'tumor samples ready: {tumor_samples_ready}')
-    #print(f'normal samples ready: {normal_samples_ready}')
 
     # start the pipeline with the correct pairs. 
     # will use these arguments to start pipeline. 
@@ -267,24 +161,6 @@ hg38ref: yes')
     # (if sample has been run before and now it has new fastqs in current run, outputdir already exists). 
     # should old outputdir be moved to archive? 
 
-#    for t in tumor_samples_ready:
-#        if t.slims_info["content_id"] in started_samples:
-#            continue
-#        for n in normal_samples_ready:
-#            if n.slims_info["content_id"] in started_samples:
-#                continue
-#            if t.slims_info['tumorNormalID'] == n.slims_info['tumorNormalID']:
-#                logger.info(f'Starting wgs_somatic with arguments: \n \
-#runnormal: {Rctx_run.run_name} \n \
-#runtumor: {Rctx_run.run_name} \n \
-#tumorsample: {t.slims_info["content_id"]} \n \
-#normalsample: {n.slims_info["content_id"]} \n \
-#normalfastqs: {os.path.join(Rctx_run.run_path, "fastq")} \n \
-#tumorfastqs: {os.path.join(Rctx_run.run_path, "fastq")} \n \
-#outputdir: {os.path.join("/seqstore/webfolders/wgs/barncancer/hg38", t.slims_info["content_id"])} \n \
-#igvuser: barncancer_hg38 \n \
-#hg38ref: yes')
-#                started_samples.extend((t.slims_info["content_id"], n.slims_info["content_id"]))
 
 
    # next step here is to actually start the pipeline with these arguments

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -118,7 +118,7 @@ def wrapper():
 
         # Get T/N pair info in a dict for samples and link additional fastqs from other runs
         for sctx in Rctx_run.sample_contexts:
-            pair_dict = get_pair_dict(sctx, Rctx.run_tag)
+            pair_dict = get_pair_dict(sctx, Rctx.run_tag, logger)
             pair_dict_all_pairs.update(pair_dict)
 
     # Uses the dictionary of T/N samples to put the correct pairs together and finds the correct input arguments to the pipeline

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -110,8 +110,8 @@ def wrapper():
 
     # using lists to keep track of stuff... could maybe be done in a better way...
     #additional_run_paths = []
-    tumor_samples = []
-    normal_samples = []
+    #tumor_samples = []
+    #normal_samples = []
     pair_ids_in_run = []
     started_samples = []
     pair_dict_all_pairs = {}
@@ -156,11 +156,11 @@ def wrapper():
         # Get run paths for samples (or other part of t/n pair) with additional fastqs in other runs
         for sctx in Rctx_run.sample_contexts:
             #run_paths = get_pair_and_run_paths(sctx, Rctx.run_tag)
-            print(f'sctx slims info: {sctx.slims_info["content_id"]}, {sctx.slims_info["tumorNormalType"]}, {sctx.slims_info["tumorNormalID"]}')
+            #print(f'sctx slims info: {sctx.slims_info["content_id"]}, {sctx.slims_info["tumorNormalType"]}, {sctx.slims_info["tumorNormalID"]}')
             pair_dict = get_pair_and_run_paths(sctx, Rctx.run_tag)
-            print(f'pair dict hej {pair_dict}')
+            #print(f'pair dict hej {pair_dict}')
             pair_dict_all_pairs.update(pair_dict)
-        print(f'pair dict all pairs: {pair_dict_all_pairs}')
+        #print(f'pair dict all pairs: {pair_dict_all_pairs}')
             #if run_paths:
                 # removes that there is a list of lists and makes just one list and removes duplicates
                 #run_paths = list(set(list(chain.from_iterable(run_paths))))
@@ -169,6 +169,42 @@ def wrapper():
                 #    if r not in additional_run_paths:
                 #        additional_run_paths.append(r)
     #print(f'additional run paths: {additional_run_paths}')
+
+    #print(f'pair dict all pairs: {pair_dict_all_pairs}')
+    for key in pair_dict_all_pairs:
+        #print(f'DICT: {pair_dict_all_pairs.get(key)}')
+        if 'tumor' in pair_dict_all_pairs.get(key):
+            t = key
+            t_ID = [val for val in pair_dict_all_pairs.get(key) if val != 'tumor'][0]
+            #t_ID.remove('tumor')
+            #ID = pair_dict_all_pairs.get(key).remove('tumor') 
+            #print(f't: {t}, t_ID: {t_ID}')
+            #tumor_samples.append(key)
+            for k in pair_dict_all_pairs:
+                #print(f'k: {k}')
+                #print(f'hejsan {pair_dict_all_pairs.get(k)}')
+                if 'normal' in pair_dict_all_pairs.get(k):
+                    n = k
+                    #print(f'n: {n}')
+                    n_ID = [val for val in pair_dict_all_pairs.get(k) if val != 'normal'][0]
+                    #print(f'n_ID: {n_ID}')
+                    #n_ID.remove('normal')
+                    if n_ID == t_ID or t_ID == n.split("DNA")[1] or n_ID == t.split("DNA")[1]:
+                        #print(f'{t} and {n} pair!')
+                        logger.info(f'Starting wgs_somatic with arguments: \n \
+runnormal: {Rctx_run.run_name} \n \
+runtumor: {Rctx_run.run_name} \n \
+tumorsample: {t} \n \
+normalsample: {n} \n \
+normalfastqs: {os.path.join(Rctx_run.run_path, "fastq")} \n \
+tumorfastqs: {os.path.join(Rctx_run.run_path, "fastq")} \n \
+outputdir: {os.path.join("/seqstore/webfolders/wgs/barncancer/hg38", t)} \n \
+igvuser: barncancer_hg38 \n \
+hg38ref: yes')
+
+    #print(f'tumor samples {tumor_samples}')
+    #print(f'normal samples {normal_samples}') 
+
 
     # get Rctx and Sctx for additional runs that have samples related to current run
     # i realized that i don't actually use "additionalRctx" for anything now. 
@@ -185,32 +221,32 @@ def wrapper():
     # Could maybe make a dictionary of tumor:normal
 
     # get tumor and normal samples related to current run from approved samples
-    for Sctx in sample_status['approved']:
-        print(f'sample status approved sample id {Sctx.sample_id}')
-        if Rctx_run.run_tag == Sctx.sample_id.split("_",1)[1]:
+    #for Sctx in sample_status['approved']:
+    #    print(f'sample status approved sample id {Sctx.sample_id}')
+        #if Rctx_run.run_tag == Sctx.sample_id.split("_",1)[1]:
             # use both tumorNormalID and sample name (minus "DNA") as pair ids since we will change pair ids to be normalname for tumor and tumorname for normal 
-            pair_ids_in_run.append(Sctx.slims_info["tumorNormalID"])
-            pair_ids_in_run.append(Sctx.sample_name.split("DNA")[1])
-        if Sctx.slims_info['tumorNormalType'] == 'tumor':
-            tumor_samples.append(Sctx)
-        elif Sctx.slims_info['tumorNormalType'] == 'normal':
-            normal_samples.append(Sctx)
-        else:
-            logger.info(f'Warning! {Sctx.slims_info["content_id"]} is not set as tumor or normal.')
+        #pair_ids_in_run.append(Sctx.slims_info["tumorNormalID"])
+        #pair_ids_in_run.append(Sctx.sample_name.split("DNA")[1])
+        #if Sctx.slims_info['tumorNormalType'] == 'tumor':
+        #    tumor_samples.append(Sctx)
+        #elif Sctx.slims_info['tumorNormalType'] == 'normal':
+        #    normal_samples.append(Sctx)
+        #else:
+        #    logger.info(f'Warning! {Sctx.slims_info["content_id"]} is not set as tumor or normal.')
     
     # make list of unique pair ids in current run
-    pair_ids_in_run = list(set(pair_ids_in_run))
-    logger.info(f'pair IDs in run: {pair_ids_in_run}')
+    #pair_ids_in_run = list(set(pair_ids_in_run))
+    #logger.info(f'pair IDs in run: {pair_ids_in_run}')
 
 
 
     # find tumor/normal pairs in the run and start pipeline
 
     # get lists of ready samples and remove duplicates from list
-    tumor_samples_ready = list(set(get_samples_ready(tumor_samples, pair_ids_in_run, Rctx_run.run_tag)))
-    normal_samples_ready = list(set(get_samples_ready(normal_samples, pair_ids_in_run, Rctx_run.run_tag)))
-    print(f'tumor samples ready: {tumor_samples_ready}')
-    print(f'normal samples ready: {normal_samples_ready}')
+    #tumor_samples_ready = list(set(get_samples_ready(tumor_samples, pair_ids_in_run, Rctx_run.run_tag)))
+    #normal_samples_ready = list(set(get_samples_ready(normal_samples, pair_ids_in_run, Rctx_run.run_tag)))
+    #print(f'tumor samples ready: {tumor_samples_ready}')
+    #print(f'normal samples ready: {normal_samples_ready}')
 
     # start the pipeline with the correct pairs. 
     # will use these arguments to start pipeline. 
@@ -231,24 +267,24 @@ def wrapper():
     # (if sample has been run before and now it has new fastqs in current run, outputdir already exists). 
     # should old outputdir be moved to archive? 
 
-    for t in tumor_samples_ready:
-        if t.slims_info["content_id"] in started_samples:
-            continue
-        for n in normal_samples_ready:
-            if n.slims_info["content_id"] in started_samples:
-                continue
-            if t.slims_info['tumorNormalID'] == n.slims_info['tumorNormalID']:
-                logger.info(f'Starting wgs_somatic with arguments: \n \
-runnormal: {Rctx_run.run_name} \n \
-runtumor: {Rctx_run.run_name} \n \
-tumorsample: {t.slims_info["content_id"]} \n \
-normalsample: {n.slims_info["content_id"]} \n \
-normalfastqs: {os.path.join(Rctx_run.run_path, "fastq")} \n \
-tumorfastqs: {os.path.join(Rctx_run.run_path, "fastq")} \n \
-outputdir: {os.path.join("/seqstore/webfolders/wgs/barncancer/hg38", t.slims_info["content_id"])} \n \
-igvuser: barncancer_hg38 \n \
-hg38ref: yes')
-                started_samples.extend((t.slims_info["content_id"], n.slims_info["content_id"]))
+#    for t in tumor_samples_ready:
+#        if t.slims_info["content_id"] in started_samples:
+#            continue
+#        for n in normal_samples_ready:
+#            if n.slims_info["content_id"] in started_samples:
+#                continue
+#            if t.slims_info['tumorNormalID'] == n.slims_info['tumorNormalID']:
+#                logger.info(f'Starting wgs_somatic with arguments: \n \
+#runnormal: {Rctx_run.run_name} \n \
+#runtumor: {Rctx_run.run_name} \n \
+#tumorsample: {t.slims_info["content_id"]} \n \
+#normalsample: {n.slims_info["content_id"]} \n \
+#normalfastqs: {os.path.join(Rctx_run.run_path, "fastq")} \n \
+#tumorfastqs: {os.path.join(Rctx_run.run_path, "fastq")} \n \
+#outputdir: {os.path.join("/seqstore/webfolders/wgs/barncancer/hg38", t.slims_info["content_id"])} \n \
+#igvuser: barncancer_hg38 \n \
+#hg38ref: yes')
+#                started_samples.extend((t.slims_info["content_id"], n.slims_info["content_id"]))
 
 
    # next step here is to actually start the pipeline with these arguments


### PR DESCRIPTION
Don't create Sctx/Rctx objects for additional runs anymore. Only looks for fastq files and T/N info instead of using the classes to create objects. 

There are two classes, RunContext and SampleContext. For the current run found by looking for new demultiplexed runs, context objects are generated. First, Rctx objects are generated for all runs found in local run paths. But if it has been previously analyzed, it does not continue. For Rctx that it continues with, Sctx for each sample in that run are generated. 

Previously, to get info about samples in current run that have additional fastqs in previous runs, Rctx and Sctx were created for those additional previous runs as well. This was not neccessary, a lot of unused extra info and objects were generated. 

Now it doesn’t create the extra Rctx and Sctx objects for additional runs. Now it just looks for samples in other runs that are related to samples in current run (= same DNA no or other part of T/N pair) and links the additional fastqs that need to be linked and saves T/N pair info for all samples needed in a dict. 
