### PR TITLE
Add webstore IGV sharing

### DIFF
--- a/configs/config_hg38.json
+++ b/configs/config_hg38.json
@@ -99,7 +99,8 @@
             "igvdatadir": "/seqstore/webfolders/igv/data",
             "updateigv": "/apps/bio/repos/igv_xml_sync/igv_xml_sync.sh",
             "bcftools": "/apps/bio/software/bcftools/1.9/bin/bcftools",
-            "bgzip": "/apps/bio/software/htslib/htslib/bgzip"
+            "bgzip": "/apps/bio/software/htslib/htslib/bgzip",
+            "webstore_igv": "/igv/pipelines/wgs-somatic/current"
         },
         "filter_variants_in_bed":
         {

--- a/pipeline.snakefile
+++ b/pipeline.snakefile
@@ -111,13 +111,13 @@ if tumorfastqdirs:
 if tumorid:
     if normalid:
         # Runs tn_workflow / paired if tumorid and normalid
-        localrules: all, upload_to_iva, share_to_igv, tn_workflow, share_to_resultdir, excel_qc
+        localrules: all, upload_to_iva, share_to_igv, share_to_igv_webstore, tn_workflow, share_to_resultdir, excel_qc
     else:
         # Runs tumoronly_workflow if tumorid but not normalid
-        localrules: all, upload_to_iva, share_to_igv, share_to_resultdir, excel_qc, tumoronly_workflow
+        localrules: all, upload_to_iva, share_to_igv, share_to_igv_webstore, share_to_resultdir, excel_qc, tumoronly_workflow
 else: 
     # Runs normalonly_workflow if normalid but not tumorid
-    localrules: all, upload_to_iva, share_to_igv, share_to_resultdir, excel_qc, normalonly_workflow
+    localrules: all, upload_to_iva, share_to_igv, share_to_igv_webstore, share_to_resultdir, excel_qc, normalonly_workflow
 ###########################################################
 
 ########################################
@@ -185,6 +185,12 @@ def get_igv_input(wildcards):
     return []
 
 
+def get_igv_webstore_input(wildcards):
+    if igvuser:
+        return expand("{workingdir}/reporting/shared_igv_webstore_files.txt", workingdir=workingdir)
+    return []
+
+
 def upload_germline_iva(wildcards):
     if ivauser:
         if ivauser == "testing":
@@ -217,5 +223,6 @@ def insilico_coverage(wildcards):
 rule all:
     input: 
         get_igv_input,
+        get_igv_webstore_input,
         expand("{workingdir}/reporting/workflow_finished.txt", workingdir=workingdir),
         alissa_vcf_conversion


### PR DESCRIPTION
Add rule taking previous IGV-share output of list of files and use it to also transfer files to webstore.

**How to test:**
Substitute names and runs for whatever sample you want to test.
```
python launch_snakemake.py --runnormal 220909_A01736_0022_BHMG7VDSX3 --output /seqstore/webfolders/wgs/barncancer/hg38/DNA92664 --normalsample DNA92665 --normalfastqs /seqstore/instruments/novaseq_A01736/Demultiplexdir/220909_A01736_0022_BHMG7VDSX3/fastq --runtumor 220909_A01736_0022_BHMG7VDSX3 --tumorsample DNA92664 --tumorfastqs /seqstore/instruments/novaseq_A01736/Demultiplexdir/220909_A01736_0022_BHMG7VDSX3/fastq --igvuser barncancer_hg38 --hg38ref yes -nc -na
```
See `/igv/pipelines/wgs-somatic/current/<name of sample>/` and verify that the relevant files are present.