### PR TITLE
Add new path for tdf-gen igvtools

### DIFF
--- a/configs/config_hg19.json
+++ b/configs/config_hg19.json
@@ -84,7 +84,8 @@
         },
        "generate_tdf":
         {
-            "tdfgen": "/seqstore/webfolders/IGVTools/igvtools.jar"
+           "igvtools_jar_path": "/apps/bio/software/igvtools/2.3.71/igvtools.jar",
+           "igvtools_memory_limit": "32768m"
         },
         "canvas":
         {

--- a/configs/config_hg38.json
+++ b/configs/config_hg38.json
@@ -87,7 +87,8 @@
         },
        "generate_tdf":
         {
-            "tdfgen": "/seqstore/webfolders/IGVTools/igvtools.jar" 
+           "igvtools_jar_path": "/apps/bio/software/igvtools/2.3.71/igvtools.jar",
+           "igvtools_memory_limit": "32768m"
         },
         "canvas":
         {

--- a/workflows/rules/mapping/generate_tdf.smk
+++ b/workflows/rules/mapping/generate_tdf.smk
@@ -5,8 +5,9 @@ rule generate_tdf:
     input:
         "{workingdir}/{stype}/realign/{sname}_REALIGNED.bam"
     params:
-        igvjar = pipeconfig["rules"]["generate_tdf"]["tdfgen"]
+        igvtools_jar_path = pipeconfig["rules"]["generate_tdf"]["igvtools_jar_path"],
+        igvtools_memory_limit = pipeconfig["rules"]["generate_tdf"]["igvtools_memory_limit"]
     output:
         "{workingdir}/{stype}/reports/{sname}_REALIGNED.bam.tdf"
     run:
-        shell("nohup java -Xmx32768m -jar {params.igvjar} count {input} {output} hg19")
+        shell("nohup java -Xmx{params.igvtools_memory_limit} -jar {params.igvtools_jar_path} count {input} {output} hg19")

--- a/workflows/rules/mapping/generate_tdf_hg38.smk
+++ b/workflows/rules/mapping/generate_tdf_hg38.smk
@@ -5,8 +5,9 @@ rule generate_tdf_hg38:
     input:
         "{workingdir}/{stype}/realign/{sname}_REALIGNED.bam"
     params:
-        igvjar = pipeconfig["rules"]["generate_tdf"]["tdfgen"]
+        igvtools_jar_path = pipeconfig["rules"]["generate_tdf"]["igvtools_jar_path"],
+        igvtools_memory_limit = pipeconfig["rules"]["generate_tdf"]["igvtools_memory_limit"]
     output:
         "{workingdir}/{stype}/reports/{sname}_REALIGNED.bam.tdf"
     run:
-        shell("nohup java -Xmx32768m -jar {params.igvjar} count {input} {output} hg38")
+        shell("nohup java -Xmx{params.igvtools_memory_limit} -jar {params.igvtools_jar_path} count {input} {output} hg38")


### PR DESCRIPTION
Tested version (same as previously) standalone but not within snakemake context. Seemed to work fine.