### PR TITLE
Output medstore

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The pipeline is started automatically when new runs with GMS-BT/AL samples appea
 
 Cron runs every 30 minutes (in crontab of cronuser)
 
-Wrapper script ```wgs_somatic-run-wrapper.py``` looks for runs in Demultiplexdir. Every time there is a new run in Demultiplexdir, it is added to text file ```/apps/bio/repos/wgs_somatic/wgs_somatic-run-wrapper.py``` to keep track of which runs that have already been analyzed. If a new run has GMS-BT/AL samples, the pipeline starts for these samples. Output is placed in working directory ```/medstore/results/wgs/wgs_somatic``` and the final result files are then copied to seqstore webfolders. You can find a more detailed description of the automation on GMS-BT confluence page.
+Wrapper script ```wgs_somatic-run-wrapper.py``` looks for runs in Demultiplexdir. Every time there is a new run in Demultiplexdir, it is added to text file ```/apps/bio/repos/wgs_somatic/novaseq_runlist.txt``` to keep track of which runs that have already been analyzed. If a new run has GMS-BT/AL samples, the pipeline starts for these samples. Output is placed in working directory ```/medstore/results/wgs/wgs_somatic``` and the final result files are then copied to seqstore webfolders. You can find a more detailed description of the automation on GMS-BT confluence page.
 
 
  ### Status (2020-10-19):

--- a/README.md
+++ b/README.md
@@ -1,13 +1,5 @@
 # The WGS Somatic Pipeline
 
-### Needs a cool name
-
-Ideas:
-
-Just anothEr Wholegenome aNalysis for detection of Somatic variants -- JEWNS
-
-WOPR - junior
-
 
 ## General description
 
@@ -27,7 +19,7 @@ WOPR - junior
 
 `$ git submodule update --init --recursive --remote`
 
-Submodules used are annotate\_manta\_canvas, b\_allele\_igv\_plot, canvas\_to\_interpreter and alissa\_connector\_upload. They can all be found at [CGG](https://github.com/ClinicalGenomicsGBG).
+Submodules used are annotate\_manta\_canvas, b\_allele\_igv\_plot, canvas\_to\_interpreter and Alissa\_API\_tools. They can all be found at [CGG](https://github.com/ClinicalGenomicsGBG).
 
 
 
@@ -37,7 +29,7 @@ Singularity images are located here: /apps/bio/singularities/wgs\_somatic/
 
 
 
-### How to run:
+### How to run manually:
 
 1. Start a screen
 
@@ -77,6 +69,16 @@ If you want to run pipeline for tumor only, simply don't use arguments runnormal
 Runnormal and runtumor is only used to create a unique samplename based on the sequencing run the data comes from. Could probably be done in a better way.
 
 
+Optional arguments to launch_snakemake.py:
+
+```--nocompress``` Disables petagene compression of bamfiles after snakemake has finished.
+
+```--noalissa``` Disables automatic upload of germline SNV_CNV vcf to Alissa. 
+
+```--copyresults``` Use this argument if you want to automatically copy result files to result directory on seqstore webfolders.
+
+
+
 Need to be on medair because python environment is hard-coded in launch_snakemake.py, also some tools in the snakemake workflow is hardcoded to install-locations on medair, and finally some dependencies such as references and databases are on medair.
 
  > \#!/apps/bio/software/anaconda2/envs/wgs_somatic/bin/python
@@ -97,6 +99,18 @@ Need to be on medair because python environment is hard-coded in launch_snakemak
  * Robust and well-documented to fit into the clinical requirements.
 
 
+ ### Yearly statistics
+
+After running the pipeline for the first time, a yearly\_statistics text file is created in the repo. Every time the pipeline is run, sample name and date/time is added to this text file.
+
+
+ ### Automatic start of pipeline
+
+The pipeline is started automatically when new runs with GMS-BT/AL samples appear in novaseq_687_gc or novaseq_A01736 Demultiplexdirs.
+
+Cron runs every 30 minutes (in crontab of cronuser)
+
+Wrapper script ```wgs_somatic-run-wrapper.py``` looks for runs in Demultiplexdir. Every time there is a new run in Demultiplexdir, it is added to text file ```/apps/bio/repos/wgs_somatic/wgs_somatic-run-wrapper.py``` to keep track of which runs that have already been analyzed. If a new run has GMS-BT/AL samples, the pipeline starts for these samples. Output is placed in working directory ```/medstore/results/wgs/wgs_somatic``` and the final result files are then copied to seqstore webfolders. You can find a more detailed description of the automation on GMS-BT confluence page.
 
 
  ### Status (2020-10-19):
@@ -127,9 +141,5 @@ Can be run using either hg38 or hg19 reference genomes.
 
  * Analyse all samples in the project with hg38 (nearly done)
  * Calculate sensitivity and precision with artificial truthset (nearly done)
-
-### Yearly statistics
-
-After running the pipeline for the first time, a yearly\_statistics text file is created in the repo. Every time the pipeline is run, sample name and date/time is added to this text file.
 
 

--- a/configs/run-wrapper_config.yaml
+++ b/configs/run-wrapper_config.yaml
@@ -20,7 +20,4 @@ hg38ref:
   GMS-BT: 'yes'
   GMS-AL: 'yes'
 
-outputdir:
-  GMS-BT: '/seqstore/webfolders/wgs/barncancer/hg38'
-  GMS-AL: '/seqstore/webfolders/wgs/barncancer/hg38'
-  G21-004: '/seqstore/webfolders/wgs/neuroblastom'
+workingdir: '/medstore/results/wgs/wgs_somatic'

--- a/configs/wrapper_conf.json
+++ b/configs/wrapper_conf.json
@@ -6,10 +6,13 @@
     "hg38conf": "config_hg38.json",
     "hg19conf": "config_hg19.json",
     "clusterconf": "cluster.yaml",
+    "resultdir_hg38": "/seqstore/webfolders/wgs/barncancer/hg38",
+    "resultdir_hg19": "/seqstore/webfolders/wgs/neuroblastom",
+    "testresultdir" : "/home/xshang/ws_testoutput/resultdir",
     "petagene":
     {
         "threads": 40,
-        "queue": "batch.q@hoth.medair.lcl",
+        "queue": "wgs.q@hoth.medair.lcl",
         "qsub_script": "petagene_compress.sh"
     },
     "alissa":

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -281,20 +281,20 @@ def analysis_main(args, output, runnormal=False, normalname=False, normalfastqs=
             analysisdict["reference"] = "hg38"
             if tumorname:
                 if normalname:
-                    analysisdict["resultdir"] = f'{config["testresultdir"]}/{tumorname}' #CHANGE BACK ALL 3: f'{config["resultdir_hg38"]}/{tumorname}'
+                    analysisdict["resultdir"] = f'{config["resultdir_hg38"]}/{tumorname}' #Use f'{config["testresultdir"]}/{tumorname}'for testing
                 else:
-                    analysisdict["resultdir"] = f'{config["testresultdir"]}/tumor_only/{tumorname}'
+                    analysisdict["resultdir"] = f'{config["resultdir_hg38"]}/tumor_only/{tumorname}'
             else:
-                analysisdict["resultdir"] = f'{config["testresultdir"]}/normal_only/{normalname}'
+                analysisdict["resultdir"] = f'{config["resultdir_hg38"]}/normal_only/{normalname}'
         else:
             analysisdict["reference"] = "hg19"
             if tumorname:
                 if normalname:
-                    analysisdict["resultdir"] = f'{config["testresultdir"]}/{tumorname}'#CHANGE BACK ALL 3: f'{config["resultdir_hg19"]}/{tumorname}'
+                    analysisdict["resultdir"] = f'{config["resultdir_hg19"]}/{tumorname}'
                 else:
-                    analysisdict["resultdir"] = f'{config["testresultdir"]}/tumor_only/{tumorname}'
+                    analysisdict["resultdir"] = f'{config["resultdir_hg19"]}/tumor_only/{tumorname}'
             else:
-                analysisdict["resultdir"] = f'{config["testresultdir"]}/normal_only/{normalname}'
+                analysisdict["resultdir"] = f'{config["resultdir_hg19"]}/normal_only/{normalname}'
         if tumorname:
             with open(f"{runconfigs}/{tumorid}_config.json", 'w') as analysisconf:
                 json.dump(analysisdict, analysisconf, ensure_ascii=False, indent=4)

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -94,7 +94,7 @@ def petagene_compress_bam(outputdir, igvuser, hg38ref, tumorname=False, normalna
     if normalname:
         standardout = f"{outputdir}/logs/{normalname}_petagene_compression_standardout.txt"
         standarderr = f"{outputdir}/logs/{normalname}_petagene_compression_standarderr.txt"
-        qsub_args = ["qsub", "-N", f"WGSSomatic-{tumorname}_petagene_compress_bam", "-q", queue, "-o", standardout, "-e", standarderr, qsub_script, igvdir, normalname]
+        qsub_args = ["qsub", "-N", f"WGSSomatic-{normalname}_petagene_compress_bam", "-q", queue, "-o", standardout, "-e", standarderr, qsub_script, igvdir, normalname]
         subprocess.call(qsub_args, shell=False)
 
 def alissa_upload(outputdir, normalname, runnormal, ref=False):

--- a/petagene_compress.sh
+++ b/petagene_compress.sh
@@ -4,10 +4,9 @@
 #$ -l excl=1
 #$ -pe mpi 40
 
-OUTPUTDIR=$(echo "$1")
+IGVDIR="$1"
+SAMPLENAME="$2"
 
-find $OUTPUTDIR -name "*.bam" -not -name "*_REALIGNED.bam" -not -name "*_realignedTNscope.bam" -exec rm {} \;
-find $OUTPUTDIR -name "*.bam.bai" -not -name "*_REALIGNED.bam.bai" -not -name "*_realignedTNscope.bam.bai" -exec rm {} \;
 
-find $OUTPUTDIR -name "*_REALIGNED.bam" -exec petasuite -c -X --numthreads 40 -m bqfilt --validate full {} \;
-#find $OUTPUTDIR -name "*_realignedTNscope.bam" -exec petasuite -c -X --numthreads 40 -m bqfilt --validate full {} \;
+find $IGVDIR -name "*$SAMPLENAME*" -name "*_REALIGNED.bam" -exec petasuite -c -X --numthreads 40 -m bqfilt --validate full {} \;
+#find $IGVDIR -name "*$SAMPLENAME*" -name "*_REALIGNED.bam" -exec echo {} \;

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -20,7 +20,7 @@ from context import RunContext, SampleContext
 from helpers import setup_logger
 from tools.slims import get_sample_slims_info, SlimsSample, find_more_fastqs, get_pair_dict
 from tools.email import start_email, end_email, error_email
-from launch_snakemake import analysis_main, petagene_compress_bam, yearly_stats, alissa_upload
+from launch_snakemake import analysis_main, petagene_compress_bam, yearly_stats, alissa_upload, copy_results
 
 
 # Store info about samples to use for sending report emails
@@ -95,25 +95,29 @@ def get_pipeline_args(config, logger, Rctx_run, t=None, n=None):
         normalsample = n
         normalfastqs = os.path.join(Rctx_run.run_path, "fastq")
         if not t:
-            outputdir = os.path.join(config['outputdir']['GMS-BT'], "normal_only", normalsample)
+            outputdir = os.path.join(config['workingdir'], "normal_only", normalsample)
             #outputdir = os.path.join("/home/xshang/ws_testoutput/outdir/", "normal_only", normalsample) #use for testing
-            pipeline_args = {'runnormal': f'{runnormal}', 'output': f'{outputdir}', 'normalname': f'{normalsample}', 'normalfastqs': f'{normalfastqs}', 'igvuser': f'{igvuser}', 'hg38ref': f'{hg38ref}'}
+            pipeline_args = {'runnormal': f'{runnormal}', 'output': f'{outputdir}', 'normalname': f'{normalsample}', 'normalfastqs': f'{normalfastqs}', 'igvuser': f'{igvuser}', 'hg38ref': f'{hg38ref}', 'runtumor': None}
     if t:
         runtumor = Rctx_run.run_name
         tumorsample = t
         tumorfastqs = os.path.join(Rctx_run.run_path, "fastq")
         if not n:
-            outputdir = os.path.join(config['outputdir']['GMS-BT'], "tumor_only", tumorsample)
+            outputdir = os.path.join(config['workingdir'], "tumor_only", tumorsample)
             #outputdir = os.path.join("/home/xshang/ws_testoutput/outdir/", "tumor_only", tumorsample) #use for testing
             pipeline_args = {'output': f'{outputdir}', 'runtumor': f'{runtumor}', 'tumorname': f'{tumorsample}', 'tumorfastqs': f'{tumorfastqs}', 'igvuser': f'{igvuser}', 'hg38ref': f'{hg38ref}', 'runnormal': None}
         else:
-            outputdir = os.path.join(config['outputdir']['GMS-BT'], tumorsample)
+            outputdir = os.path.join(config['workingdir'], tumorsample)
             #outputdir = os.path.join("/home/xshang/ws_testoutput/outdir/", tumorsample) #use for testing
             pipeline_args = {'runnormal': f'{runnormal}', 'output': f'{outputdir}', 'normalname': f'{normalsample}', 'normalfastqs': f'{normalfastqs}', 'runtumor': f'{runtumor}', 'tumorname': f'{tumorsample}', 'tumorfastqs': f'{tumorfastqs}', 'igvuser': f'{igvuser}', 'hg38ref': f'{hg38ref}'}
 
     if os.path.exists(outputdir):
-        logger.info(f'Outputdir exists for {tumorsample}. Renaming old outputdir {outputdir} to {outputdir}_old')
-        os.rename(outputdir, f'{outputdir}_old')
+        if t:
+            logger.info(f'Outputdir exists for {tumorsample}. Renaming old outputdir {outputdir} to {outputdir}_old')
+            os.rename(outputdir, f'{outputdir}_old')
+        else:
+            logger.info(f'Outputdir exists for {normalsample}. Renaming old outputdir {outputdir} to {outputdir}_old')
+            os.rename(outputdir, f'{outputdir}_old')
 
     return pipeline_args
 
@@ -132,8 +136,8 @@ def check_ok(outputdir):
         return False
 
 
-def analysis_end(outputdir, tumorsample=None, normalsample=None, runnormal=None, hg38ref=None):
-    '''Function to check if analysis has finished correctly and add to yearly stats and start petagene compression'''
+def analysis_end(outputdir, tumorsample=None, normalsample=None, runtumor=None, runnormal=None, hg38ref=None):
+    '''Function to check if analysis has finished correctly and add to yearly stats, upload to alissa, copy results and start petagene compression'''
 
     if os.path.isfile(f"{outputdir}/reporting/workflow_finished.txt"):
         if tumorsample:
@@ -141,11 +145,14 @@ def analysis_end(outputdir, tumorsample=None, normalsample=None, runnormal=None,
                 # these functions are only executed if snakemake workflow has finished successfully
                 alissa_upload(outputdir, normalsample, runnormal, hg38ref)
                 yearly_stats(tumorsample, normalsample)
+                copy_results(outputdir, runnormal=runnormal, normalname=normalsample, runtumor=runtumor, tumorname=tumorsample)
             else:
                 yearly_stats(tumorsample, 'None')
+                copy_results(outputdir, runtumor=runtumor, tumorname=tumorsample)
             petagene_compress_bam(outputdir, tumorsample)
         else:
             yearly_stats('None', normalsample)
+            copy_results(outputdir, runnormal=runnormal, normalname=normalsample)
             alissa_upload(outputdir, normalsample, runnormal, hg38ref)
             petagene_compress_bam(outputdir, normalsample)
     else:
@@ -237,7 +244,7 @@ def wrapper(instrument):
 
                             outputdir = pipeline_args.get('output')
                             check_ok_outdirs.append(outputdir)
-                            end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, t, n, pipeline_args['runnormal'], pipeline_args['hg38ref'])))
+                            end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, t, n, pipeline_args['runtumor'], pipeline_args['runnormal'], pipeline_args['hg38ref'])))
 
                             paired_samples.append(t)
                             paired_samples.append(n)
@@ -266,7 +273,7 @@ def wrapper(instrument):
 
                 outputdir = pipeline_args.get('output')
                 check_ok_outdirs.append(outputdir)
-                end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, tumorsample, normalsample,  pipeline_args['runnormal'], pipeline_args['hg38ref'])))
+                end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, tumorsample, normalsample, pipeline_args['runtumor'], pipeline_args['runnormal'], pipeline_args['hg38ref'])))
 
         # Start several samples at the same time
         for t in threads:

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -327,9 +327,6 @@ def wrapper(instrument):
 
     # some arguments are hardcoded right now, need to fix this. 
     # only considers barncancer hg38 (GMS-AL + GMS-BT samples) right now. 
-    # could have outputdirs and arguments in config and get them from there. 
-
-    # this will only work for pairs. have to consider tumor only/normal only as well. 
 
     # the arguments runtumor and runnormal could be "wrong" by doing it like this 
     # since they use run name of current run 

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -136,7 +136,7 @@ def check_ok(outputdir):
         return False
 
 
-def analysis_end(outputdir, tumorsample=None, normalsample=None, runtumor=None, runnormal=None, hg38ref=None):
+def analysis_end(outputdir, igvuser, tumorsample=None, normalsample=None, runtumor=None, runnormal=None, hg38ref=None):
     '''Function to check if analysis has finished correctly and add to yearly stats, upload to alissa, copy results and start petagene compression'''
 
     if os.path.isfile(f"{outputdir}/reporting/workflow_finished.txt"):
@@ -146,15 +146,16 @@ def analysis_end(outputdir, tumorsample=None, normalsample=None, runtumor=None, 
                 alissa_upload(outputdir, normalsample, runnormal, hg38ref)
                 yearly_stats(tumorsample, normalsample)
                 copy_results(outputdir, runnormal=runnormal, normalname=normalsample, runtumor=runtumor, tumorname=tumorsample)
+                petagene_compress_bam(outputdir, igvuser, hg38ref, tumorname=tumorsample, normalname=normalsample)
             else:
                 yearly_stats(tumorsample, 'None')
                 copy_results(outputdir, runtumor=runtumor, tumorname=tumorsample)
-            petagene_compress_bam(outputdir, tumorsample)
+                petagene_compress_bam(outputdir, igvuser, hg38ref, tumorname=tumorsample)
         else:
             yearly_stats('None', normalsample)
             copy_results(outputdir, runnormal=runnormal, normalname=normalsample)
             alissa_upload(outputdir, normalsample, runnormal, hg38ref)
-            petagene_compress_bam(outputdir, normalsample)
+            petagene_compress_bam(outputdir, igvuser, hg38ref, normalname=normalsample)
     else:
         pass
 
@@ -244,7 +245,7 @@ def wrapper(instrument):
 
                             outputdir = pipeline_args.get('output')
                             check_ok_outdirs.append(outputdir)
-                            end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, t, n, pipeline_args['runtumor'], pipeline_args['runnormal'], pipeline_args['hg38ref'])))
+                            end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, pipeline_args['igvuser'], t, n, pipeline_args['runtumor'], pipeline_args['runnormal'], pipeline_args['hg38ref'])))
 
                             paired_samples.append(t)
                             paired_samples.append(n)
@@ -273,7 +274,7 @@ def wrapper(instrument):
 
                 outputdir = pipeline_args.get('output')
                 check_ok_outdirs.append(outputdir)
-                end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, tumorsample, normalsample, pipeline_args['runtumor'], pipeline_args['runnormal'], pipeline_args['hg38ref'])))
+                end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, pipeline_args['igvuser'], tumorsample, normalsample, pipeline_args['runtumor'], pipeline_args['runnormal'], pipeline_args['hg38ref'])))
 
         # Start several samples at the same time
         for t in threads:

--- a/workflows/rules/mapping/mapping.smk
+++ b/workflows/rules/mapping/mapping.smk
@@ -42,7 +42,7 @@ rule mapping:
     singularity:
         pipeconfig["singularities"]["sentieon"]["sing"]
     output:
-        "{workingdir}/{stype}/mapping/{fastqpattern}.bam"
+        temp("{workingdir}/{stype}/mapping/{fastqpattern}.bam")
     shell:
         "echo $HOSTNAME;"
         "{params.sentieon} bwa mem "
@@ -54,7 +54,7 @@ rule dedup:
     input:
         bamfiles = get_mapping
     output:
-        "{workingdir}/{stype}/dedup/{sname}_DEDUP.bam",
+        temp("{workingdir}/{stype}/dedup/{sname}_DEDUP.bam"),
         "{workingdir}/{stype}/dedup/{sname}_DEDUP.txt"
     params:
         threads = clusterconf["dedup"]["threads"],

--- a/workflows/rules/mapping/mapping_hg38.smk
+++ b/workflows/rules/mapping/mapping_hg38.smk
@@ -42,7 +42,7 @@ rule mapping:
     singularity:
         pipeconfig["singularities"]["sentieon"]["sing"]
     output:
-        "{workingdir}/{stype}/mapping/{fastqpattern}.bam"
+        temp("{workingdir}/{stype}/mapping/{fastqpattern}.bam")
     shell:
         "echo $HOSTNAME;"
         "{params.sentieon} bwa mem "
@@ -54,7 +54,7 @@ rule dedup:
     input:
         bamfiles = get_mapping
     output:
-        "{workingdir}/{stype}/dedup/{sname}_DEDUP.bam",
+        temp("{workingdir}/{stype}/dedup/{sname}_DEDUP.bam"),
         "{workingdir}/{stype}/dedup/{sname}_DEDUP.txt"
     params:
         threads = clusterconf["dedup"]["threads"],

--- a/workflows/rules/qc/coverage_hg38.smk
+++ b/workflows/rules/qc/coverage_hg38.smk
@@ -14,7 +14,7 @@ rule wgs_coverage:
     output:
         "{workingdir}/{stype}/reports/{sname}_WGScov.tsv"
     shell:
-        "{params.sentieon} driver -i {input} -r {params.reference} "
+        "{params.sentieon} driver -t {params.threads} -i {input} -r {params.reference} "
             "--interval chr1,chr2,chr3,chr4,chr5,chr6,chr7,chr8,chr9,chr10,chr11,chr12,chr13,chr14,chr15,chr16,chr17,chr18,chr19,chr20,chr21,chr22,chrX,chrY,chrM --algo WgsMetricsAlgo {output}"
 
 rule y_coverage:
@@ -29,4 +29,4 @@ rule y_coverage:
     output:
         "{workingdir}/{stype}/reports/{sname}_Ycov.tsv"
     shell:
-        "{params.sentieon} driver -i {input} -r {params.reference} --interval chrY --algo WgsMetricsAlgo {output}"
+        "{params.sentieon} driver -t {params.threads} -i {input} -r {params.reference} --interval chrY --algo WgsMetricsAlgo {output}"

--- a/workflows/rules/results_sharing/share_to_igv.smk
+++ b/workflows/rules/results_sharing/share_to_igv.smk
@@ -42,7 +42,7 @@ if tumorid:
                     link_sharefile = os.path.abspath(sharefile)
                     #shell("ln -sf {link_sharefile} {igvsharedir}")
                     if sharefile.endswith("REALIGNED.bam"):
-                        shell("mv {link_sharefile} {igvsharedir}")
+                        shell("rsync {link_sharefile} {igvsharedir}")
                         shell("rsync {link_sharefile}.bai {igvsharedir}")
                         continue
                     if sharefile.endswith(".vcf.gz"):
@@ -83,7 +83,7 @@ if tumorid:
                     #shell("ln -sf {link_sharefile} {igvsharedir}")
                     if sharefile.endswith("REALIGNED.bam"):
                         shell("rsync {link_sharefile}.bai {igvsharedir}")
-                        shell("mv {link_sharefile} {igvsharedir}")
+                        shell("rsync {link_sharefile} {igvsharedir}")
                         continue
                     if sharefile.endswith(".vcf.gz"):
                         shell("rsync {link_sharefile}.csi {igvsharedir}")
@@ -123,7 +123,7 @@ else:
                 #shell("ln -sf {link_sharefile} {igvsharedir}")
                 if sharefile.endswith("REALIGNED.bam"):
                     shell("rsync {link_sharefile}.bai {igvsharedir}")
-                    shell("mv {link_sharefile} {igvsharedir}")
+                    shell("rsync {link_sharefile} {igvsharedir}")
                     continue
                 if sharefile.endswith(".vcf.gz"):
                     shell("rsync {link_sharefile}.csi {igvsharedir}")

--- a/workflows/rules/results_sharing/share_to_igv.smk
+++ b/workflows/rules/results_sharing/share_to_igv.smk
@@ -21,10 +21,10 @@ if tumorid:
                 expand("{workingdir}/{stype}/manta/{sname}_somatic_MantaNOBNDs.vcf", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{workingdir}/{stype}/manta/{sname}_germline_MantaBNDs.vcf", workingdir=workingdir, sname=normalid, stype=sampleconfig[normalname]["stype"]),
                 expand("{workingdir}/{stype}/manta/{sname}_germline_MantaNOBNDs.vcf", workingdir=workingdir, sname=normalid, stype=sampleconfig[normalname]["stype"]),
-                expand("{workingdir}/{stype}/tnscope/{sname}_REALIGNED_realignedTNscope.bam", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+                #expand("{workingdir}/{stype}/tnscope/{sname}_REALIGNED_realignedTNscope.bam", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{workingdir}/{stype}/pindel/{sname}_pindel.vcf", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"])
             params:
-                updateigv = pipeconfig["rules"]["share_to_igv"]["updateigv"],
+                #updateigv = pipeconfig["rules"]["share_to_igv"]["updateigv"],
                 igvdatadir = pipeconfig["rules"]["share_to_igv"]["igvdatadir"],
                 bgzip = pipeconfig["rules"]["share_to_igv"]["bgzip"],
                 bcftools = pipeconfig["rules"]["share_to_igv"]["bcftools"]
@@ -40,11 +40,14 @@ if tumorid:
                         shell(f"{params.bcftools} index -f {sharefile}.gz")
                         sharefile = os.path.abspath(f"{sharefile}.gz")
                     link_sharefile = os.path.abspath(sharefile)
-                    shell("ln -sf {link_sharefile} {igvsharedir}")
+                    #shell("ln -sf {link_sharefile} {igvsharedir}")
                     if sharefile.endswith("REALIGNED.bam"):
-                        shell("ln -sf {link_sharefile}.bai {igvsharedir}")
+                        shell("mv {link_sharefile} {igvsharedir}")
+                        shell("rsync {link_sharefile}.bai {igvsharedir}")
+                        continue
                     if sharefile.endswith(".vcf.gz"):
-                        shell("ln -sf {link_sharefile}.csi {igvsharedir}")
+                        shell("rsync {link_sharefile}.csi {igvsharedir}")
+                    shell("rsync {link_sharefile} {igvsharedir}")
                 #shell("{params.updateigv}")
                 shell("echo {input} >> {output}")
 
@@ -58,10 +61,10 @@ if tumorid:
                 expand("{workingdir}/{stype}/reports/{sname}_REALIGNED.bam.tdf", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{workingdir}/{stype}/reports/{sname}_baf.igv", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{workingdir}/{stype}/manta/{sname}_somatic_MantaBNDs.vcf", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-                expand("{workingdir}/{stype}/manta/{sname}_somatic_MantaNOBNDs.vcf", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-                expand("{workingdir}/{stype}/tnscope/{sname}_REALIGNED_realignedTNscope.bam", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"])
+                expand("{workingdir}/{stype}/manta/{sname}_somatic_MantaNOBNDs.vcf", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"])#,
+                #expand("{workingdir}/{stype}/tnscope/{sname}_REALIGNED_realignedTNscope.bam", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"])
             params:
-                updateigv = pipeconfig["rules"]["share_to_igv"]["updateigv"],
+                #updateigv = pipeconfig["rules"]["share_to_igv"]["updateigv"],
                 igvdatadir = pipeconfig["rules"]["share_to_igv"]["igvdatadir"],
                 bgzip = pipeconfig["rules"]["share_to_igv"]["bgzip"],
                 bcftools = pipeconfig["rules"]["share_to_igv"]["bcftools"]
@@ -77,11 +80,14 @@ if tumorid:
                         shell(f"{params.bcftools} index -f {sharefile}.gz")
                         sharefile = os.path.abspath(f"{sharefile}.gz")
                     link_sharefile = os.path.abspath(sharefile)
-                    shell("ln -sf {link_sharefile} {igvsharedir}")
+                    #shell("ln -sf {link_sharefile} {igvsharedir}")
                     if sharefile.endswith("REALIGNED.bam"):
-                        shell("ln -sf {link_sharefile}.bai {igvsharedir}")
+                        shell("rsync {link_sharefile}.bai {igvsharedir}")
+                        shell("mv {link_sharefile} {igvsharedir}")
+                        continue
                     if sharefile.endswith(".vcf.gz"):
-                        shell("ln -sf {link_sharefile}.csi {igvsharedir}")
+                        shell("rsync {link_sharefile}.csi {igvsharedir}")
+                    shell("rsync {link_sharefile} {igvsharedir}")
                 #shell("{params.updateigv}")
                 shell("echo {input} >> {output}")
 
@@ -114,10 +120,13 @@ else:
                     shell(f"{params.bcftools} index -f {sharefile}.gz")
                     sharefile = os.path.abspath(f"{sharefile}.gz")
                 link_sharefile = os.path.abspath(sharefile)
-                shell("ln -sf {link_sharefile} {igvsharedir}")
+                #shell("ln -sf {link_sharefile} {igvsharedir}")
                 if sharefile.endswith("REALIGNED.bam"):
-                    shell("ln -sf {link_sharefile}.bai {igvsharedir}")
+                    shell("rsync {link_sharefile}.bai {igvsharedir}")
+                    shell("mv {link_sharefile} {igvsharedir}")
+                    continue
                 if sharefile.endswith(".vcf.gz"):
-                    shell("ln -sf {link_sharefile}.csi {igvsharedir}")
+                    shell("rsync {link_sharefile}.csi {igvsharedir}")
+                shell("rsync {link_sharefile} {igvsharedir}")
             #shell("{params.updateigv}")
             shell("echo {input} >> {output}")

--- a/workflows/rules/variantcalling/pindel.smk
+++ b/workflows/rules/variantcalling/pindel.smk
@@ -18,31 +18,60 @@ else:
             pindelConfig = "{workingdir}/{stype}/pindel/{sname}_pindelConfig.txt"
         shell:
             "echo '{input.tumorbam}\t300\t{tumorname}'>{output.pindelConfig}"
+if normalid:
+    rule pindel:
+        input:
+            tumorbam = expand("{workingdir}/{stype}/dedup/{sname}_DEDUP.bam", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+            normalbam = expand("{workingdir}/{stype}/dedup/{sname}_DEDUP.bam", workingdir=workingdir, sname=normalid, stype=sampleconfig[normalname]["stype"]),
+            pindelConfig = expand("{workingdir}/{stype}/pindel/{sname}_pindelConfig.txt", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"])
+        params:
+            bed = pipeconfig["rules"]["pindel"]["bed"],
+            reference = pipeconfig["referencegenome"],
+            threads = clusterconf["pindel"]["threads"],
+            x = 2,
+            B = 60
+        singularity:
+            pipeconfig["singularities"]["pindel"]["sing"]
+        output:
+            "{workingdir}/{stype}/pindel/{sname}_BP",
+            "{workingdir}/{stype}/pindel/{sname}_CloseEndMapped",
+            "{workingdir}/{stype}/pindel/{sname}_D",
+            "{workingdir}/{stype}/pindel/{sname}_INT_final",
+            "{workingdir}/{stype}/pindel/{sname}_INV",
+            "{workingdir}/{stype}/pindel/{sname}_LI",
+            "{workingdir}/{stype}/pindel/{sname}_RP",
+            "{workingdir}/{stype}/pindel/{sname}_SI",
+            "{workingdir}/{stype}/pindel/{sname}_TD"
+        shell:
+            "echo $HOSTNAME;"
+            " (pindel -f {params.reference} -i {input.pindelConfig} -T {params.threads} -x {params.x} -B {params.B} -j {params.bed} -o {workingdir}/{wildcards.stype}/pindel/{wildcards.sname} ) "
 
-rule pindel:
-    input:
-        pindelConfig = expand("{workingdir}/{stype}/pindel/{sname}_pindelConfig.txt", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"])
-    params:
-        bed = pipeconfig["rules"]["pindel"]["bed"],
-        reference = pipeconfig["referencegenome"],
-        threads = clusterconf["pindel"]["threads"],
-        x = 2,
-        B = 60
-    singularity:
-        pipeconfig["singularities"]["pindel"]["sing"]
-    output:
-        "{workingdir}/{stype}/pindel/{sname}_BP",
-        "{workingdir}/{stype}/pindel/{sname}_CloseEndMapped",
-        "{workingdir}/{stype}/pindel/{sname}_D",
-        "{workingdir}/{stype}/pindel/{sname}_INT_final",
-        "{workingdir}/{stype}/pindel/{sname}_INV",
-        "{workingdir}/{stype}/pindel/{sname}_LI",
-        "{workingdir}/{stype}/pindel/{sname}_RP",
-        "{workingdir}/{stype}/pindel/{sname}_SI",
-        "{workingdir}/{stype}/pindel/{sname}_TD"
-    shell:
-        "echo $HOSTNAME;"
-        " (pindel -f {params.reference} -i {input.pindelConfig} -T {params.threads} -x {params.x} -B {params.B} -j {params.bed} -o {workingdir}/{wildcards.stype}/pindel/{wildcards.sname} ) "
+else:
+    rule pindel:
+        input:
+            tumorbam = expand("{workingdir}/{stype}/dedup/{sname}_DEDUP.bam", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+            pindelConfig = expand("{workingdir}/{stype}/pindel/{sname}_pindelConfig.txt", workingdir=workingdir, sname=tumorid, stype=sampleconfig[tumorname]["stype"])
+        params:
+            bed = pipeconfig["rules"]["pindel"]["bed"],
+            reference = pipeconfig["referencegenome"],
+            threads = clusterconf["pindel"]["threads"],
+            x = 2,
+            B = 60
+        singularity:
+            pipeconfig["singularities"]["pindel"]["sing"]
+        output:
+            "{workingdir}/{stype}/pindel/{sname}_BP",
+            "{workingdir}/{stype}/pindel/{sname}_CloseEndMapped",
+            "{workingdir}/{stype}/pindel/{sname}_D",
+            "{workingdir}/{stype}/pindel/{sname}_INT_final",
+            "{workingdir}/{stype}/pindel/{sname}_INV",
+            "{workingdir}/{stype}/pindel/{sname}_LI",
+            "{workingdir}/{stype}/pindel/{sname}_RP",
+            "{workingdir}/{stype}/pindel/{sname}_SI",
+            "{workingdir}/{stype}/pindel/{sname}_TD"
+        shell:
+            "echo $HOSTNAME;"
+            " (pindel -f {params.reference} -i {input.pindelConfig} -T {params.threads} -x {params.x} -B {params.B} -j {params.bed} -o {workingdir}/{wildcards.stype}/pindel/{wildcards.sname} ) "
 
 rule pindel2vcf:
     input:


### PR DESCRIPTION
Use /medstore/results/wgs/wgs_somatic as workingdir and only copy relevant resultfiles to /seqstore/webfolders after pipeline has finished. Copy/move files to igv instead of symlink. Petagene compress bamfile in igv dir after pipeline has finished. Will test again how well it works together with the IGV changes that Jens made after merging into development. Will we have to petagene compress the bamfile in both IGV dirs...?
Only save realigned bam files (use temp for mapping/dedup bam files)