### PR TITLE
Dedup fix

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,16 +1,16 @@
 [submodule "workflows/scripts/annotate_manta_canvas"]
 	path = workflows/scripts/annotate_manta_canvas
-	url = git@github.com:ClinicalGenomicsGBG/annotate_manta_canvas
+	url = https://github.com/ClinicalGenomicsGBG/annotate_manta_canvas.git
         ignore = dirty
 [submodule "workflows/scripts/b_allele_igv_plot"]
 	path = workflows/scripts/b_allele_igv_plot
-	url = git@github.com:ClinicalGenomicsGBG/b_allele_igv_plot
+	url = https://github.com/ClinicalGenomicsGBG/b_allele_igv_plot.git
         ignore = dirty        
 [submodule "workflows/scripts/canvas_to_interpreter"]
 	path = workflows/scripts/canvas_to_interpreter
-	url = git@github.com:ClinicalGenomicsGBG/canvas_to_interpreter
+	url = https://github.com/ClinicalGenomicsGBG/canvas_to_interpreter.git
         ignore = dirty
 [submodule "workflows/scripts/Alissa_API_tools"]
 	path = workflows/scripts/Alissa_API_tools
-	url = git@github.com:ClinicalGenomicsGBG/Alissa_API_tools.git
+	url = https://github.com/ClinicalGenomicsGBG/Alissa_API_tools.git
 	branch = main

--- a/workflows/rules/mapping/mapping_hg38.smk
+++ b/workflows/rules/mapping/mapping_hg38.smk
@@ -74,7 +74,7 @@ rule dedup:
             "{output.score}; "
         "{params.sentieon} driver "
             "-t {params.threads} "
-            "-i {input.bam} "
+            "{params.bamfiles} "
             "--algo Dedup "
             "--rmdup "
             "--score_info {output.score} "


### PR DESCRIPTION
Lately, when a sample has fastq inputs from several sequencing runs, dedup has crashed. This hasn't been a problem before, it used to be able to handle several bam inputs. Made a fix for this and tested it and it works OK, now it can have several bam inputs again.

Also updated urls for submodules.