### PR TITLE
Download hcp fix

### DIFF
--- a/configs/run-wrapper_config.yaml
+++ b/configs/run-wrapper_config.yaml
@@ -9,13 +9,15 @@ novaseq_A01736:
   demultiplex_path: "/seqstore/novaseq_A01736/Demultiplexdir/"
   seq_name_regex: '^[0-9]{6}_A01736_[0-9]{4}_.{10}$'
 
-previous_runs_file_path: 'novaseq_runlist.txt'
+previous_runs_file_path: 'novaseq_runlist_test.txt'
 
 hg38ref:
   GMS-BT: 'yes'
   GMS-AL: 'yes'
 
 workingdir: '/medstore/results/wgs/wgs_somatic'
+
+hcp_download_dir: '/medstore/projects/P23-075/wgs_somatic/hcp_downloads'
 
 hcp:
   qsub_script: 'hcp_download_fq.sh'

--- a/configs/run-wrapper_config.yaml
+++ b/configs/run-wrapper_config.yaml
@@ -9,7 +9,7 @@ novaseq_A01736:
   demultiplex_path: "/seqstore/novaseq_A01736/Demultiplexdir/"
   seq_name_regex: '^[0-9]{6}_A01736_[0-9]{4}_.{10}$'
 
-previous_runs_file_path: 'novaseq_runlist_test.txt'
+previous_runs_file_path: 'novaseq_runlist.txt'
 
 hg38ref:
   GMS-BT: 'yes'
@@ -17,6 +17,7 @@ hg38ref:
 
 workingdir: '/medstore/results/wgs/wgs_somatic'
 
+#hcp_download_dir: '/medstore/results/wgs/tmp/hcp_downloads'
 hcp_download_dir: '/medstore/projects/P23-075/wgs_somatic/hcp_downloads'
 
 hcp:

--- a/configs/wrapper_conf.json
+++ b/configs/wrapper_conf.json
@@ -8,7 +8,7 @@
     "clusterconf": "cluster.yaml",
     "resultdir_hg38": "/webstore/clinical/routine/wgs_somatic/current",
     "resultdir_hg19": "/seqstore/webfolders/wgs/neuroblastom",
-    "testresultdir" : "/medstore/projects/P23-075/wgs_somatic/local_repo/unit_tests/testoutput/resultdir",
+    "testresultdir" : "/medstore/projects/P23-075/wgs_somatic/local_repo/unit_tests/testoutput/resultdir", 
     "webstore_api_url": "http://webstore.sa.gu.se/api/paths",
     "alissa":
     {

--- a/configs/wrapper_conf.json
+++ b/configs/wrapper_conf.json
@@ -8,7 +8,7 @@
     "clusterconf": "cluster.yaml",
     "resultdir_hg38": "/webstore/clinical/routine/wgs_somatic/current",
     "resultdir_hg19": "/seqstore/webfolders/wgs/neuroblastom",
-    "testresultdir" : "/home/xshang/ws_testoutput/resultdir",
+    "testresultdir" : "/medstore/projects/P23-075/wgs_somatic/local_repo/unit_tests/testoutput/resultdir",
     "webstore_api_url": "http://webstore.sa.gu.se/api/paths",
     "alissa":
     {


### PR DESCRIPTION
## Contents
Review deadline: 1 Nov 2023

Main reviewer: @fannyhb 

### The What

Needed to change location of downloads for old samples no longer in seqstore to a location on medstore.

### The Why

The original hcp_download module had the download location set to the 
instrument folder on seqstore. 

### The How

Modified config to include a separate path to a folder on medstore for downloading files from hcp.
Also added this hcp_path and the hcp runtag to tools/slims.py.
Moved testresultdir from home folder to a medstore location. 

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

1. Create unit test for modified download_hcp module
2. Use past results/dummy files to test modifications 
3. Create test environment and directories for running tests outside of main repo
4. Run automated pipeline in env
5. Check that results from test runs compared to manual run match

### Installation and initiation

None

### Tests

Unit test located under medstore : P23-075/wgs_somatic/local_repo/unit_tests/
Results passed to subdirectory : testoutput/resultdir

### Expected outcome

Files that are not in run path will be downloaded to medstore location and will be able to run with demultiplexed data from instruments.

## Verifications
- [ ] Code reviewed by @fannyhb @alvaralmstedt 
- [x] Code tested by @AlinaO90 
