### PR TITLE
Copy unfiltered somatic and config to webstore

### DIFF
--- a/configs/run-wrapper_config.yaml
+++ b/configs/run-wrapper_config.yaml
@@ -9,7 +9,7 @@ novaseq_A01736:
   demultiplex_path: "/seqstore/novaseq_A01736/Demultiplexdir/"
   seq_name_regex: '^[0-9]{6}_A01736_[0-9]{4}_.{10}$'
 
-previous_runs_file_path: 'novaseq_runlist_test.txt'
+previous_runs_file_path: 'novaseq_runlist.txt'
 
 hg38ref:
   GMS-BT: 'yes'

--- a/configs/run-wrapper_config.yaml
+++ b/configs/run-wrapper_config.yaml
@@ -9,13 +9,15 @@ novaseq_A01736:
   demultiplex_path: "/seqstore/novaseq_A01736/Demultiplexdir/"
   seq_name_regex: '^[0-9]{6}_A01736_[0-9]{4}_.{10}$'
 
-previous_runs_file_path: 'novaseq_runlist.txt'
+previous_runs_file_path: 'novaseq_runlist_test.txt'
 
 hg38ref:
   GMS-BT: 'yes'
   GMS-AL: 'yes'
 
 workingdir: '/medstore/results/wgs/wgs_somatic'
+
+hcp_download_dir: '/medstore/projects/P23-075/wgs_somatic/hcp_downloads'
 
 hcp:
   qsub_script: 'hcp_download_fq.sh'

--- a/configs/wrapper_conf.json
+++ b/configs/wrapper_conf.json
@@ -8,7 +8,7 @@
     "clusterconf": "cluster.yaml",
     "resultdir_hg38": "/webstore/clinical/routine/wgs_somatic/current",
     "resultdir_hg19": "/seqstore/webfolders/wgs/neuroblastom",
-    "testresultdir" : "/home/xshang/ws_testoutput/resultdir",
+    "testresultdir" : "/medstore/projects/P23-075/wgs_somatic/local_repo/unit_tests/testoutput/resultdir",
     "webstore_api_url": "http://webstore.sa.gu.se/api/paths",
     "alissa":
     {

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -280,11 +280,11 @@ def analysis_main(args, output, runnormal=False, normalname=False, normalfastqs=
             analysisdict["reference"] = "hg38"
             if tumorname:
                 if normalname:
-                    analysisdict["resultdir"] =  f'{config["resultdir"]}/{tumorname}' #f'{config["resultdir_hg38"]}/{basename_output}' #Use f'{config["testresultdir"]}/{tumorname}'for testing
+                    analysisdict["resultdir"] =  f'{config["resultdir_hg38"]}/{basename_output}' #Use f'{config["testresultdir"]}/{tumorname}'for testing
                 else:
-                    analysisdict["resultdir"] = f'{config["resultdir"]}/tumor_only/{basename_output}'
+                    analysisdict["resultdir"] = f'{config["resultdir_hg38"]}/tumor_only/{basename_output}'
             else:
-                analysisdict["resultdir"] = f'{config["resultdir"]}/normal_only/{basename_output}'
+                analysisdict["resultdir"] = f'{config["resultdir_hg38"]}/normal_only/{basename_output}'
         else:
             analysisdict["reference"] = "hg19"
             if tumorname:

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -105,23 +105,33 @@ def copy_results(outputdir, runnormal=None, normalname=None, runtumor=None, tumo
     os.makedirs(resultdir, exist_ok=True)
     igv_dir = os.path.join(resultdir, 'igv_files')
     os.makedirs(igv_dir, exist_ok=True)
+    
 
     # Find resultfiles to copy to resultdir on webstore
+    copy_files = []
+    files_match = ['.xlsx', 'CNV_SNV_germline.vcf.gz', 'somatic.vcf.gz', 'refseq3kfilt.vcf.gz']
     for f in os.listdir(workdir):
         f = os.path.join(workdir, f)
+        if os.path.isdir(f):
+            if 'configs' in f: 
+                copy(os.path.join(workdir, 'configs', 'config_hg38.json'), resultdir)
+                # copy config file to resultdir
+                logger(f"Run configuration file copied successfully")
         if os.path.isfile(f):
-            if '.xlsx' in f or 'refseq3kfilt' in f or 'CNV_SNV_germline' in f:
-                try:
-                    copy(f, resultdir)
-                    logger(f"{f} copied successfully")
-                except:
-                    logger(f"Error occurred while copying {f}")
-            else:
-                try:
-                    copy(f, igv_dir)
-                    logger(f"{f} copied successfully")
-                except:
-                    logger(f"Error occurred while copying {f}")
+            for files in files_match:
+                copy_files = copy_files + glob.glob(os.path.join(workdir, f'*{files}*'))
+                if f in copy_files:
+                    try:
+                        copy(f, resultdir)
+                        logger(f"{f} copied successfully")
+                    except:
+                        logger(f"Error occurred while copying {f}")
+                else:
+                    try:
+                        copy(f, igv_dir)
+                        logger(f"{f} copied successfully")
+                    except:
+                        logger(f"Error occurred while copying {f}")
 
     # Make webstore portal API call to make path searchable
     webstore_api_url = config["webstore_api_url"]
@@ -158,7 +168,7 @@ def analysis_main(args, output, runnormal=False, normalname=False, normalfastqs=
             if tumorfastqs.endswith("/"):
                 tumorfastqs = tumorfastqs[:-1]
 
-        
+
         #################################################################
         # Validate Inputs
         ################################################################
@@ -270,11 +280,11 @@ def analysis_main(args, output, runnormal=False, normalname=False, normalfastqs=
             analysisdict["reference"] = "hg38"
             if tumorname:
                 if normalname:
-                    analysisdict["resultdir"] = f'{config["resultdir_hg38"]}/{basename_output}' #Use f'{config["testresultdir"]}/{tumorname}'for testing
+                    analysisdict["resultdir"] =  f'{config["resultdir"]}/{tumorname}' #f'{config["resultdir_hg38"]}/{basename_output}' #Use f'{config["testresultdir"]}/{tumorname}'for testing
                 else:
-                    analysisdict["resultdir"] = f'{config["resultdir_hg38"]}/tumor_only/{basename_output}'
+                    analysisdict["resultdir"] = f'{config["resultdir"]}/tumor_only/{basename_output}'
             else:
-                analysisdict["resultdir"] = f'{config["resultdir_hg38"]}/normal_only/{basename_output}'
+                analysisdict["resultdir"] = f'{config["resultdir"]}/normal_only/{basename_output}'
         else:
             analysisdict["reference"] = "hg19"
             if tumorname:

--- a/workflows/rules/results_sharing/share_to_resultdir.smk
+++ b/workflows/rules/results_sharing/share_to_resultdir.smk
@@ -9,6 +9,7 @@ if tumorid:
         rule share_to_resultdir:
             input:
                 expand("{stype}/{caller}/{sname}_{vcftype}_refseq3kfilt.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], stype=sampleconfig[tumorname]["stype"], caller="tnscope", sname=tumorid, vcftype="somatic"),
+                expand("{stype}/{caller}/{sname}_{vcftype}.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], stype=sampleconfig[tumorname]["stype"], caller="tnscope", sname=tumorid, vcftype="somatic"),
                 expand("{stype}/{caller}/{sname}_{vcftype}_refseq3kfilt.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], stype=sampleconfig[normalname]["stype"], caller="dnascope", sname=normalid, vcftype="germline"),
                 expand("qc_report/{tumorname}_qc_stats.xlsx", tumorname=tumorname),
                 expand("{stype}/canvas/{sname}_CNV_somatic.vcf.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @fannyhb 

### The What

In launch script and for results shared file, added copy of unfiltered somatic vcf file and configuration file for each individual run.

### The Why

For barn tumor banken harmonisation between nodes, need to have unfiltered somatic file for TMB calculation and config file
so clinicians can see the genelist/other parameters being used.

### The How


### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

1. Create test folder for output
2. Create unit test for modified copy function
3. Use past results/dummy files to test new copy function with unit testing

### Installation and initiation

No change in usage

### Tests

Unit test located under medstore : P23-075/wgs_somatic/local_repo/unit_tests/ 
Results passed to subdirectory : testoutput

### Expected outcome

unfiltered and refseq filtered somatic.vcf.gz files will be copied to webstore, as will the Sample configuration file.

## Verifications
- [ ] Code reviewed by @fannyhb , @alvaralmstedt 
- [x] Code tested by @AlinaO90 
