### PR TITLE
Fix bugs with hcp download

### DIFF
--- a/configs/run-wrapper_config.yaml
+++ b/configs/run-wrapper_config.yaml
@@ -25,3 +25,4 @@ hcp:
   queue: 'routine.q'
   threads: 1
   credentials: '/medstore/credentials/gmc-west_legacy_credentials.json'
+  peta_script: 'run_petasuite.sh' 

--- a/run_petasuite.sh
+++ b/run_petasuite.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -l
+#$ -cwd
+#$ -S /bin/bash
+#$ -l excl=1
+#$ -pe mpi 20
+
+
+module load petasuite
+petasuite --md5match -d *.fasterq -t 20

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -91,20 +91,14 @@ def get_pipeline_args(config, logger, Rctx_run, t=None, n=None):
 
     if n:
         normalsample = n
-        try:
-            normalfastqs = os.path.join(Rctx_run.run_path, "fastq")
-            runnormal = Rctx_run.run_name
-            if not os.path.exists(os.path.join(Rctx_run.run_path,"fastq", n+"*.gz")):
-                runnormal = glob.glob(os.path.join(hcp_downloads,"*",normalsample+"*.gz"))[1].split('/')[-2]
-                normalfastqs = os.path.dirname(glob.glob(os.path.join(hcp_downloads,"*",normalsample+"*.gz"))[1])
-        except:
-            if not t:
-                date, _, _, chip, *_ = runnormal.split('_')
-                normalid= '_'.join([normalsample, date, chip])
-                outputdir = os.path.join(config['workingdir'], "normal_only", normalid)
-                #outputdir = os.path.join("/medstore/projects/P23-075/wgs_somatic/local_repo/unit_tests/testoutput/resultdir", "normal_only", normalsample) #use for testing
-                pipeline_args = {'runnormal': f'{runnormal}', 'output': f'{outputdir}', 'normalname': f'{normalsample}', 'normalfastqs': f'{normalfastqs}', 'hg38ref': f'{hg38ref}', 'runtumor': None}
-       #Check that path of hcp downloads contains gz files for the normal sample
+        normalfastqs = os.path.join(Rctx_run.run_path, "fastq")
+        runnormal = Rctx_run.run_name
+        if not t:
+            date, _, _, chip, *_ = runnormal.split('_')
+            normalid= '_'.join([normalsample, date, chip])
+            outputdir = os.path.join(config['workingdir'], "normal_only", normalid)
+            #outputdir = os.path.join("/medstore/projects/P23-075/wgs_somatic/local_repo/unit_tests/testoutput/resultdir", "normal_only", normalsample) #use for testing
+            pipeline_args = {'runnormal': f'{runnormal}', 'output': f'{outputdir}', 'normalname': f'{normalsample}', 'normalfastqs': f'{normalfastqs}', 'hg38ref': f'{hg38ref}', 'runtumor': None}
     if t:
         runtumor = Rctx_run.run_name
         tumorsample = t
@@ -294,6 +288,7 @@ def wrapper(instrument):
                 check_ok_outdirs.append(outputdir)
                 end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, tumorsample, normalsample, pipeline_args['runtumor'], pipeline_args['runnormal'], pipeline_args['hg38ref'])))
 
+        
         # Start several samples at the same time
         for t in threads:
             t.start()


### PR DESCRIPTION
## Contents
Review deadline: 2023-11-02

Main reviewer: @AlinaO90 

### The What
Fixing the previous download hcp patch that did not work as intended. Added a separate qsub script for petasuite and linking the downloaded fastqs to the current rundir.

### The Why
The downloading did not work for older samples and if the downloaded samples were tumor samples the files were not properly linked,

### The How


### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure
Run the wrapper on a sequencing run that has samples that need to be paired with samples that are not present on the server. Make sure that the samples are downloaded and decompressed. Make sure that the path to the samples are given as arguments to the pipeline.

### Installation and initiation

### Tests
Tested the wrapper multiple times by commenting out the part of the code that run the pipeline. Made sure that the paths to the fastq files were correct and given as arguments to the pipeline and that the samples were correctly paired. Have not tested the full pipeline from start to end.

### Expected outcome
Old samples that are located on hcp and are needed for the pairing should be downloaded to /medstore/projects/P23-075/wgs_somatic/hcp_downloads/<old_runname> and decompressed. They should then be linked to the current rundir in Demultiplexdir.

## Verifications
- [x] Code reviewed by @AlinaO90 
- [ ] Code tested by @alvaralmstedt 
