### PR TITLE
Update containing functionality to download from hcp

### DIFF
--- a/configs/config_hg38.json
+++ b/configs/config_hg38.json
@@ -132,8 +132,8 @@
         },
         "manta_summary":
         {
-            "genelist": "/apps/bio/dependencies/wgs_somatic/genelist.txt",
-            "genelist_tumoronly": "/apps/bio/dependencies/wgs_somatic/Genelist_GMS-AL_tumor-only.txt"
+            "genelist": "/apps/bio/dependencies/wgs_somatic/genelist_v1.1.txt",
+            "genelist_tumoronly": "/apps/bio/dependencies/wgs_somatic/Genelist_GMS-AL_tumor-only_v1.1.txt"
         },
         "pindel":
         {

--- a/configs/run-wrapper_config.yaml
+++ b/configs/run-wrapper_config.yaml
@@ -21,4 +21,4 @@ hcp:
   qsub_script: 'hcp_download_fq.sh'
   queue: 'routine.q'
   threads: 1
-  credentials: '/medstore/credentials/iris_credentials.json'
+  credentials: '/medstore/credentials/gmc-west_legacy_credentials.json'

--- a/configs/run-wrapper_config.yaml
+++ b/configs/run-wrapper_config.yaml
@@ -17,6 +17,7 @@ hg38ref:
 
 workingdir: '/medstore/results/wgs/wgs_somatic'
 
+#hcp_download_dir: '/medstore/results/wgs/tmp/hcp_downloads'
 hcp_download_dir: '/medstore/projects/P23-075/wgs_somatic/hcp_downloads'
 
 hcp:

--- a/configs/run-wrapper_config.yaml
+++ b/configs/run-wrapper_config.yaml
@@ -17,6 +17,8 @@ hg38ref:
 
 workingdir: '/medstore/results/wgs/wgs_somatic'
 
+hcp_download_dir: '/medstore/projects/P23-075/wgs_somatic/hcp_downloads'
+
 hcp:
   qsub_script: 'hcp_download_fq.sh'
   queue: 'routine.q'

--- a/configs/run-wrapper_config.yaml
+++ b/configs/run-wrapper_config.yaml
@@ -23,6 +23,6 @@ hcp_download_dir: '/medstore/projects/P23-075/wgs_somatic/hcp_downloads'
 hcp:
   qsub_script: 'hcp_download_fq.sh'
   queue: 'routine.q'
-  threads: 1
+  threads: 20
   credentials: '/medstore/credentials/gmc-west_legacy_credentials.json'
   peta_script: 'run_petasuite.sh' 

--- a/configs/run-wrapper_config.yaml
+++ b/configs/run-wrapper_config.yaml
@@ -25,3 +25,4 @@ hcp:
   queue: 'routine.q'
   threads: 1
   credentials: '/medstore/credentials/gmc-west_legacy_credentials.json'
+  peta_script: 'run_petasuite.sh' 

--- a/configs/wrapper_conf.json
+++ b/configs/wrapper_conf.json
@@ -8,7 +8,7 @@
     "clusterconf": "cluster.yaml",
     "resultdir_hg38": "/webstore/clinical/routine/wgs_somatic/current",
     "resultdir_hg19": "/seqstore/webfolders/wgs/neuroblastom",
-    "testresultdir" : "/medstore/projects/P23-075/wgs_somatic/local_repo/unit_tests/testoutput/resultdir",
+    "testresultdir" : "/medstore/projects/P23-075/wgs_somatic/local_repo/unit_tests/testoutput/resultdir", 
     "webstore_api_url": "http://webstore.sa.gu.se/api/paths",
     "alissa":
     {

--- a/configs/wrapper_conf.json
+++ b/configs/wrapper_conf.json
@@ -8,7 +8,7 @@
     "clusterconf": "cluster.yaml",
     "resultdir_hg38": "/webstore/clinical/routine/wgs_somatic/current",
     "resultdir_hg19": "/seqstore/webfolders/wgs/neuroblastom",
-    "testresultdir" : "/home/xshang/ws_testoutput/resultdir",
+    "testresultdir" : "/medstore/projects/P23-075/wgs_somatic/local_repo/unit_tests/testoutput/resultdir",
     "webstore_api_url": "http://webstore.sa.gu.se/api/paths",
     "alissa":
     {

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -105,23 +105,33 @@ def copy_results(outputdir, runnormal=None, normalname=None, runtumor=None, tumo
     os.makedirs(resultdir, exist_ok=True)
     igv_dir = os.path.join(resultdir, 'igv_files')
     os.makedirs(igv_dir, exist_ok=True)
+    
 
     # Find resultfiles to copy to resultdir on webstore
+    copy_files = []
+    files_match = ['.xlsx', 'CNV_SNV_germline.vcf.gz', 'somatic.vcf.gz', 'refseq3kfilt.vcf.gz']
     for f in os.listdir(workdir):
         f = os.path.join(workdir, f)
+        if os.path.isdir(f):
+            if 'configs' in f: 
+                copy(os.path.join(workdir, 'configs', 'config_hg38.json'), resultdir)
+                # copy config file to resultdir
+                logger(f"Run configuration file copied successfully")
         if os.path.isfile(f):
-            if '.xlsx' in f or 'refseq3kfilt' in f or 'CNV_SNV_germline' in f:
-                try:
-                    copy(f, resultdir)
-                    logger(f"{f} copied successfully")
-                except:
-                    logger(f"Error occurred while copying {f}")
-            else:
-                try:
-                    copy(f, igv_dir)
-                    logger(f"{f} copied successfully")
-                except:
-                    logger(f"Error occurred while copying {f}")
+            for files in files_match:
+                copy_files = copy_files + glob.glob(os.path.join(workdir, f'*{files}*'))
+                if f in copy_files:
+                    try:
+                        copy(f, resultdir)
+                        logger(f"{f} copied successfully")
+                    except:
+                        logger(f"Error occurred while copying {f}")
+                else:
+                    try:
+                        copy(f, igv_dir)
+                        logger(f"{f} copied successfully")
+                    except:
+                        logger(f"Error occurred while copying {f}")
 
     # Make webstore portal API call to make path searchable
     webstore_api_url = config["webstore_api_url"]
@@ -158,7 +168,7 @@ def analysis_main(args, output, runnormal=False, normalname=False, normalfastqs=
             if tumorfastqs.endswith("/"):
                 tumorfastqs = tumorfastqs[:-1]
 
-        
+
         #################################################################
         # Validate Inputs
         ################################################################
@@ -270,7 +280,7 @@ def analysis_main(args, output, runnormal=False, normalname=False, normalfastqs=
             analysisdict["reference"] = "hg38"
             if tumorname:
                 if normalname:
-                    analysisdict["resultdir"] = f'{config["resultdir_hg38"]}/{basename_output}' #Use f'{config["testresultdir"]}/{tumorname}'for testing
+                    analysisdict["resultdir"] =  f'{config["resultdir_hg38"]}/{basename_output}' #Use f'{config["testresultdir"]}/{tumorname}'for testing
                 else:
                     analysisdict["resultdir"] = f'{config["resultdir_hg38"]}/tumor_only/{basename_output}'
             else:

--- a/run_petasuite.sh
+++ b/run_petasuite.sh
@@ -2,8 +2,8 @@
 #$ -cwd
 #$ -S /bin/bash
 #$ -l excl=1
-#$ -pe mpi 20
 
+threads=$1
 
 module load petasuite
-petasuite --md5match -d *.fasterq -t 20
+petasuite --md5match -d *.fasterq -t $threads

--- a/run_petasuite.sh
+++ b/run_petasuite.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -l
+#$ -cwd
+#$ -S /bin/bash
+#$ -l excl=1
+#$ -pe mpi 20
+
+
+module load petasuite
+petasuite --md5match -d *.fasterq -t 20

--- a/tools/slims.py
+++ b/tools/slims.py
@@ -141,14 +141,10 @@ def download_hcp_fqs(fqSSample, run_path, logger, hcp_runtag):
     peta_script = os.path.join(ROOT_DIR, config["hcp"]["peta_script"])
     credentials = config["hcp"]["credentials"]
     hcp_downloads = config["hcp_download_dir"]
-#    hcp_runtag = fqSSample.fastq.cntn_cstm_runTag.value
     hcp_download_runpath = f'{hcp_downloads}/{hcp_runtag}'
-    logger.info(f"remote keys are: {remote_keys}")
-    queue = "development.q"
     for key in remote_keys:
         local_path = f'{run_path}/fastq/{os.path.basename(key)}'
         hcp_path = f'{hcp_download_runpath}/{os.path.basename(key)}'
-        logger.info(f"this key is {key}")
         if not os.path.exists(local_path) or not os.path.exists(hcp_path):
             standardout = os.path.join(ROOT_LOGGING_PATH, f"hcp_download_{os.path.basename(key)}.stdout")
             standarderr = os.path.join(ROOT_LOGGING_PATH, f"hcp_download_{os.path.basename(key)}.stderr")
@@ -159,19 +155,12 @@ def download_hcp_fqs(fqSSample, run_path, logger, hcp_runtag):
                     os.makedirs(f'{hcp_download_runpath}')
                 qsub_args = ["qsub", "-N", f"hcp_download_{os.path.basename(key)}", "-q", queue, "-sync", "y", "-o", standardout, "-e", standarderr, qsub_script, credentials, bucket, key, hcp_path] 
                 logger.info(f'Downloading {os.path.basename(key)} from HCP')
-#                subprocess.call(qsub_args)
                 cwd = os.getcwd()
                 os.chdir(f'{hcp_download_runpath}')
-                logger.info(f"current dir is: {os.getcwd()}")
-#                hcp_dir_args = ("cd", f'{hcp_downloads}/{hcp_runtag}')
-#                subrocess.call(hcp_dir_args)
                 peta_args = ["qsub", "-N", f"decompressing_file_{os.path.basename(key)}", "-q", queue, "-sync", "y", "-o", standardout_peta, "-e", standarderr_peta, peta_script] 
-#                peta_args = ["petasuite --md5match -d ","*fasterq"]
                 logger.info(f"Running petasuite with args: {peta_args}")
-#                subprocess.call(peta_args)
                 logger.info("Done with petasuite")
                 os.chdir(cwd)
-#                subprocess.call("cd", f'{cwd}')
             except FileExistsError:
                 pass
 
@@ -181,25 +170,20 @@ def link_fastqs(list_of_fq_paths, run_path, fqSSample, logger):
     with open(CONFIG_PATH, 'r') as conf:
         config = yaml.safe_load(conf)
     hcp_downloads = config["hcp_download_dir"]
-    logger.info(f'fq_paths: {list_of_fq_paths}')
     # TODO: additional fastqs need to still be in demultiplexdir. not considering downloading from hcp right now. need to consider this later...
     for fq_path in list_of_fq_paths:
         fq_link = os.path.join(run_path, "fastq", os.path.basename(fq_path))
 #        hcp_runtag = fq_path.split("/")[-3] # This could cause problems if we change the file structure
         hcp_runtag = fqSSample.fastq.cntn_cstm_runTag.value
         hcp_path =  f'{hcp_downloads}/{hcp_runtag}'
-        logger.info(f'fq_path: {fq_path}')
-        logger.info(f'hcp_path: {hcp_path}')
         if os.path.exists(fq_path): # If fq still on seqstore
         # Only links if link doesn't already exist
             if not os.path.islink(fq_link):
             # Now symlinks all additional paths to fastqs for tumor and normal in other runs.
                 os.symlink(fq_path, fq_link)
-                logger.info('tried to symlink')
         #If fq not in seqstore
         elif not os.path.exists(fq_path):
             # Check /medstore/tmp/hcp_downloads 
-            logger.info('fq_path does not exist')
             # If one DNA object has multiple fastq objects linked we want them to be in the same folder
             previously_downloaded_samples_same_DNA = sorted(glob.glob(os.path.join(hcp_downloads,"*",os.path.basename(fq_path).split('_')[0]+"*.gz")))
             if previously_downloaded_samples_same_DNA:
@@ -210,8 +194,6 @@ def link_fastqs(list_of_fq_paths, run_path, fqSSample, logger):
             if os.path.isdir(hcp_path):
                 if os.path.basename(fq_path) in os.listdir(hcp_path):
                     logger.info(f'The file {os.path.basename(fq_path)} exists in {hcp_path}')
-#                    if f.startswith(fq_path.split("/")[-1].split("_")[0]) and (f.endswith('fastq.gz') or f.endswith('fq.gz')):
-#                        logger.info(f'{hcp_path} with {fq_path.split("/")[-1].split("_")[0]} exists.')
                 else:
                     logger.info(f'{fq_path} does not exist. Need to download from hcp')
                     download_hcp_fqs(fqSSample, run_path, logger, hcp_runtag)
@@ -226,8 +208,6 @@ def link_fastqs(list_of_fq_paths, run_path, fqSSample, logger):
                 if not os.path.islink(fq_link):
                     logger.info(f"Linking {downloaded_fq_path} to {fq_link}")
                     os.symlink(downloaded_fq_path, fq_link)
-        else:
-            logger.info('Last option')
 
 def find_more_fastqs(sample_name, Rctx, logger):
     """

--- a/tools/slims.py
+++ b/tools/slims.py
@@ -153,12 +153,18 @@ def download_hcp_fqs(fqSSample, run_path, logger, hcp_runtag):
             try:
                 if not os.path.exists(hcp_download_runpath):
                     os.makedirs(f'{hcp_download_runpath}')
+                
                 qsub_args = ["qsub", "-N", f"hcp_download_{os.path.basename(key)}", "-q", queue, "-sync", "y", "-o", standardout, "-e", standarderr, qsub_script, credentials, bucket, key, hcp_path] 
                 logger.info(f'Downloading {os.path.basename(key)} from HCP')
+                subprocess.call(qsub_args)
                 cwd = os.getcwd()
                 os.chdir(f'{hcp_download_runpath}')
-                peta_args = ["qsub", "-N", f"decompressing_file_{os.path.basename(key)}", "-q", queue, "-sync", "y", "-o", standardout_peta, "-e", standarderr_peta, peta_script] 
+
+                peta_args = ["qsub", "-N", f"decompressing_file_{os.path.basename(key)}", "-q", queue, "-sync", "y", 
+                        "-pe", "mpi", f"{threads}", "-o", standardout_peta, "-e", standarderr_peta, "-v",f"THREADS={threads}",
+                        peta_script, threads] 
                 logger.info(f"Running petasuite with args: {peta_args}")
+                subprocess.call(peta_args)
                 logger.info("Done with petasuite")
                 os.chdir(cwd)
             except FileExistsError:

--- a/tools/slims.py
+++ b/tools/slims.py
@@ -162,7 +162,7 @@ def download_hcp_fqs(fqSSample, run_path, logger, hcp_runtag):
 
                 peta_args = ["qsub", "-N", f"decompressing_file_{os.path.basename(key)}", "-q", queue, "-sync", "y", 
                         "-pe", "mpi", f"{threads}", "-o", standardout_peta, "-e", standarderr_peta, "-v",f"THREADS={threads}",
-                        peta_script, threads] 
+                        peta_script, str(threads)] 
                 logger.info(f"Running petasuite with args: {peta_args}")
                 subprocess.call(peta_args)
                 logger.info("Done with petasuite")

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -91,20 +91,14 @@ def get_pipeline_args(config, logger, Rctx_run, t=None, n=None):
 
     if n:
         normalsample = n
-        try:
-            normalfastqs = os.path.join(Rctx_run.run_path, "fastq")
-            runnormal = Rctx_run.run_name
-            if not os.path.exists(os.path.join(Rctx_run.run_path,"fastq", n+"*.gz")):
-                runnormal = glob.glob(os.path.join(hcp_downloads,"*",normalsample+"*.gz"))[1].split('/')[-2]
-                normalfastqs = os.path.dirname(glob.glob(os.path.join(hcp_downloads,"*",normalsample+"*.gz"))[1])
-        except:
-            if not t:
-                date, _, _, chip, *_ = runnormal.split('_')
-                normalid= '_'.join([normalsample, date, chip])
-                outputdir = os.path.join(config['workingdir'], "normal_only", normalid)
-                #outputdir = os.path.join("/medstore/projects/P23-075/wgs_somatic/local_repo/unit_tests/testoutput/resultdir", "normal_only", normalsample) #use for testing
-                pipeline_args = {'runnormal': f'{runnormal}', 'output': f'{outputdir}', 'normalname': f'{normalsample}', 'normalfastqs': f'{normalfastqs}', 'hg38ref': f'{hg38ref}', 'runtumor': None}
-       #Check that path of hcp downloads contains gz files for the normal sample
+        normalfastqs = os.path.join(Rctx_run.run_path, "fastq")
+        runnormal = Rctx_run.run_name
+        if not t:
+            date, _, _, chip, *_ = runnormal.split('_')
+            normalid= '_'.join([normalsample, date, chip])
+            outputdir = os.path.join(config['workingdir'], "normal_only", normalid)
+            #outputdir = os.path.join("/medstore/projects/P23-075/wgs_somatic/local_repo/unit_tests/testoutput/resultdir", "normal_only", normalsample) #use for testing
+            pipeline_args = {'runnormal': f'{runnormal}', 'output': f'{outputdir}', 'normalname': f'{normalsample}', 'normalfastqs': f'{normalfastqs}', 'hg38ref': f'{hg38ref}', 'runtumor': None}
     if t:
         runtumor = Rctx_run.run_name
         tumorsample = t
@@ -294,6 +288,7 @@ def wrapper(instrument):
                 check_ok_outdirs.append(outputdir)
                 end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, tumorsample, normalsample, pipeline_args['runtumor'], pipeline_args['runnormal'], pipeline_args['hg38ref'])))
 
+        
         # Start several samples at the same time
         for t in threads:
             t.start()

--- a/workflows/rules/results_sharing/share_to_resultdir.smk
+++ b/workflows/rules/results_sharing/share_to_resultdir.smk
@@ -9,6 +9,7 @@ if tumorid:
         rule share_to_resultdir:
             input:
                 expand("{stype}/{caller}/{sname}_{vcftype}_refseq3kfilt.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], stype=sampleconfig[tumorname]["stype"], caller="tnscope", sname=tumorid, vcftype="somatic"),
+                expand("{stype}/{caller}/{sname}_{vcftype}.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], stype=sampleconfig[tumorname]["stype"], caller="tnscope", sname=tumorid, vcftype="somatic"),
                 expand("{stype}/{caller}/{sname}_{vcftype}_refseq3kfilt.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], stype=sampleconfig[normalname]["stype"], caller="dnascope", sname=normalid, vcftype="germline"),
                 expand("qc_report/{tumorname}_qc_stats.xlsx", tumorname=tumorname),
                 expand("{stype}/canvas/{sname}_CNV_somatic.vcf.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),


### PR DESCRIPTION
## Contents
Review deadline: 2023-12-08

Main reviewer: @AlinaO90 

### The What
Added functionality to download samples from hcp.
Make sure that we match a tumor sample with a normal and vice verse.
A new gene list has been added.

### The Why
Many samples require old samples to be matched with. Previously we had to manually download these samples and then manually run the pipeline. 

### The How
Fixed the download_hcp script, added functionality for decompressing with petasuite.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure
Make sure the right samples are downloaded and that the correct pairs are formed.

### Installation and initiation
Same as before.

### Tests

### Expected outcome

## Verifications
- [x] Code reviewed by @fannyhb 
- [x] Code tested by @fannyhb 
