### PR TITLE
Adding function to handle decompression with both petasuite and spring

### DIFF
--- a/configs/run-wrapper_config.yaml
+++ b/configs/run-wrapper_config.yaml
@@ -25,4 +25,5 @@ hcp:
   queue: 'routine.q'
   threads: 20
   credentials: '/medstore/credentials/gmc-west_legacy_credentials.json'
-  peta_script: 'run_petasuite.sh' 
+  peta_script: 'run_petasuite.sh'
+  spring_script: 'run_spring.sh' 

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -110,6 +110,9 @@ def copy_results(outputdir, runnormal=None, normalname=None, runtumor=None, tumo
     # Find resultfiles to copy to resultdir on webstore
     copy_files = []
     files_match = ['.xlsx', 'CNV_SNV_germline.vcf.gz', 'somatic.vcf.gz', 'refseq3kfilt.vcf.gz']
+    for files in files_match:
+        copy_files = copy_files + glob.glob(os.path.join(workdir, f'*{files}*'))
+    copy_files = set(copy_files)
     for f in os.listdir(workdir):
         f = os.path.join(workdir, f)
         if os.path.isdir(f):
@@ -118,20 +121,18 @@ def copy_results(outputdir, runnormal=None, normalname=None, runtumor=None, tumo
                 # copy config file to resultdir
                 logger(f"Run configuration file copied successfully")
         if os.path.isfile(f):
-            for files in files_match:
-                copy_files = copy_files + glob.glob(os.path.join(workdir, f'*{files}*'))
-                if f in copy_files:
-                    try:
-                        copy(f, resultdir)
-                        logger(f"{f} copied successfully")
-                    except:
-                        logger(f"Error occurred while copying {f}")
-                else:
-                    try:
-                        copy(f, igv_dir)
-                        logger(f"{f} copied successfully")
-                    except:
-                        logger(f"Error occurred while copying {f}")
+            if f in copy_files:
+                try:
+                    copy(f, resultdir)
+                    logger(f"{f} copied successfully")
+                except:
+                    logger(f"Error occurred while copying {f}")
+            else:
+                try:
+                    copy(f, igv_dir)
+                    logger(f"{f} copied successfully")
+                except:
+                    logger(f"Error occurred while copying {f}")
 
     # Make webstore portal API call to make path searchable
     webstore_api_url = config["webstore_api_url"]

--- a/run_spring.sh
+++ b/run_spring.sh
@@ -1,0 +1,11 @@
+#!/bin/bash -l
+#$ -cwd
+#$ -S /bin/bash
+#$ -l excl=1
+
+COMPRESSED=$1
+DECOMPRESSED=$2
+THREADS=$3
+
+module load spring
+spring -d -i $COMPRESSED -o $DECOMPRESSED -t $THREADS -g


### PR DESCRIPTION
## Contents

Implemented functionality to decompress using Spring. Moved the code related to decompression to a separate function in slims.py for readability.

Review deadline:

Main reviewer: @AlinaO90 

### The What
Functionality to decompress Spring compressed files.

### The Why
Since late 2023 we are using Spring instead of petasuite to compress files. Therefore we need functionality to decompress using both petasuite and Spring when downloading files from hcp.

### The How


### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure
@fannyhb has tested the wrapper on two cases: one where files compressed with petasuite was downloaded and another one where the files were compressed using Spring. Has not been testing in a full run.

### Installation and initiation

### Tests

### Expected outcome
Should be able to automatically download and decompress files compressed with both petasuite and Spring from HCP. Everything else should be identical to previous versions.

## Verifications
- [ ] Code reviewed by @AlinaO90 
- [ ] Code tested by @alvaralmstedt 
