### PR TITLE
fix: Ensure runs with multiple samplesheets are picked up

### DIFF
--- a/configs/run-wrapper_config.yaml
+++ b/configs/run-wrapper_config.yaml
@@ -2,12 +2,12 @@
 novaseq_687_gc:
   root_path: "/seqstore/novaseq_687_gc/"
   demultiplex_path: "/seqstore/novaseq_687_gc/Demultiplexdir/"
-  seq_name_regex: '^[0-9]{6}_A00687_[0-9]{4}_.{10}$'
+  seq_name_regex: '^[0-9]{6}_A00687_[0-9]{4}_.{10}(?:\+.{8})?$'
 
 novaseq_A01736:
   root_path: "/seqstore/novaseq_A01736/"
   demultiplex_path: "/seqstore/novaseq_A01736/Demultiplexdir/"
-  seq_name_regex: '^[0-9]{6}_A01736_[0-9]{4}_.{10}$'
+  seq_name_regex: '^[0-9]{6}_A01736_[0-9]{4}_.{10}(?:\+.{8})?$'
 
 previous_runs_file_path: 'novaseq_runlist.txt'
 

--- a/context.py
+++ b/context.py
@@ -5,7 +5,7 @@ class RunContext:
         self.run_path = run_path
         self.run_name = os.path.basename(run_path)
         self.run_date = self.run_name.split('_')[0]
-        self.run_flowcell = self.run_name.split('_')[-1]
+        self.run_flowcell = self.run_name.split('_')[-1].split('+')[0]
         self.run_tag = '_'.join([self.run_date, self.run_flowcell])
         #self.samplesheet_path = os.path.join(run_path, 'SampleSheet.csv')
         self.demultiplex_summary_path = os.path.join(run_path, 'demuxer.json')


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @alvaralmstedt 

### The What
To be able to pool different projects in the same sequencing run we need to use more than one samplesheet per sequencing run. The updated Demuxer code handle this by creating multiple output folder in the Demultiplexdir where the "normal" output name  rundate_machine_side_flowcell will have an additional +hash (i.e. rundate_machine_side_flowcell+hash). 

This change is making sure that wgs-somatic detects run-folders generated this way and that it correctly identifies the different parts of the folder name.

### The Why
To be able to automatically start when projects have been pooled during sequencing.

### The How


### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure
Tested on demultiplex folders generated with new demuxer code.

### Installation and initiation
Update runlists to contain TESTATESTA folders.

### Tests

### Expected outcome
Should start on run folder generated with both old and new version of demuxer.

## Verifications
- [ ] Code reviewed by @alvaralmstedt 
- [x] Code tested by @fannyhb 