### PR TITLE
Fix multiple download bug

### DIFF
--- a/configs/cluster.yaml
+++ b/configs/cluster.yaml
@@ -12,6 +12,9 @@ mapping:
     error: "WGSsomatic_{rule}_{wildcards.fastqpattern}.stderr"
     threads: 40
 
+cram:
+    threads: 40
+
 rtgtools_eval:
     threads: 10
 

--- a/tools/slims.py
+++ b/tools/slims.py
@@ -312,6 +312,8 @@ def get_pair_dict(Sctx, Rctx, logger):
             find_more_fastqs(pair.cntn_id.value, Rctx, logger)
     for p in pairs2:
         pair_slims_sample = translate_slims_info(p)
+        if not pair_slims_sample['tumorNormalType'] == pair_type:
+            continue
         if not pair_slims_sample['content_id'] in pair_dict:
             logger.info(f'Using sample {pair_slims_sample["content_id"]} as a pair to {Sctx.slims_info["content_id"]} (tumorNormalID {Sctx.slims_info["tumorNormalID"]}), but it does not have a matching tumorNormalID')
         if not pair_slims_sample['tumorNormalType']:

--- a/workflows/rules/mapping/cram.smk
+++ b/workflows/rules/mapping/cram.smk
@@ -8,7 +8,7 @@ rule cram:
     singularity:
         pipeconfig["singularities"]["samtools"]["sing"]
     params:
-        threads = clusterconf["mapping"]["threads"],
+        threads = clusterconf["cram"]["threads"],
         referencegenome = pipeconfig["referencegenome"]
     shadow:
         pipeconfig["rules"].get("cram", {}).get("shadow", pipeconfig.get("shadow", False))


### PR DESCRIPTION
## Contents
Review deadline:

Main reviewer: @octocat

### The What
If new tumor sample already has a normal and a tumor with the same tumorID the old tumor sample has also been downloaded and analyzed. Fixed this.
Also added rule specific thread option for cram compression.

### The Why
Unnecessary and confusing if we analyze old samples and send out the results.

### The How
Minor "if check" in slims.py

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [x] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

### Installation and initiation

### Tests
Have tested function get_pair_dict in slims.py so that we get the expected outcome.

### Expected outcome
One pair created for each incoming sample.

## Verifications
- [x] Code reviewed by @fannyhb 
- [x] Code tested by @fannyhb 
