### PR TITLE
Tmb calculation

### DIFF
--- a/configs/config_hg38.json
+++ b/configs/config_hg38.json
@@ -148,6 +148,11 @@
         {
             "bcftools": "/apps/bio/software/bcftools/1.9/bin/bcftools",
             "bgzip": "/apps/bio/software/htslib/htslib/bgzip"
+        },
+        "tmb_calculation":
+        {
+            "bcftools": "/apps/bio/software/bcftools/1.9/bin/bcftools",
+            "genome_size": 3049315783
         }
     }
 }

--- a/configs/config_hg38.json
+++ b/configs/config_hg38.json
@@ -152,7 +152,7 @@
         "tmb_calculation":
         {
             "bcftools": "/apps/bio/software/bcftools/1.9/bin/bcftools",
-            "genome_size": 3049315783
+            "effective_genome_size": 3049315783
         }
     }
 }

--- a/configs/filters.yaml
+++ b/configs/filters.yaml
@@ -1,0 +1,5 @@
+tmb_filter:
+  min_mutant_allele_fraction: 0.05
+  min_mutant_allele_reads: 3
+  min_coverage: 10
+

--- a/configs/wrapper_conf.json
+++ b/configs/wrapper_conf.json
@@ -6,6 +6,7 @@
     "hg38conf": "config_hg38.json",
     "hg19conf": "config_hg19.json",
     "clusterconf": "cluster.yaml",
+    "filterconf": "filters.yaml",
     "resultdir_hg38": "/webstore/clinical/routine/wgs_somatic/current",
     "resultdir_hg19": "/seqstore/webfolders/wgs/neuroblastom",
     "testresultdir" : "/medstore/projects/P23-075/wgs_somatic/local_repo/unit_tests/testoutput/resultdir", 

--- a/helpers.py
+++ b/helpers.py
@@ -1,21 +1,15 @@
 import yaml
 import json
 import logging
-from definitions import ROOT_DIR
 
 def read_config(configpath):
     with open(configpath, 'r') as configfile:
-        config_data = json.load(configfile)
-        return config_data
-
-def read_clusterconf():
-    with open(f"{ROOT_DIR}/configs/cluster.yaml") as inputfile:
-        inputfile_info = yaml.load(inputfile, Loader=yaml.FullLoader)
-        return inputfile_info
-
-def read_passconfig():
-    with open("/root/password_config.json", 'r') as configfile:
-        config_data = json.load(configfile)
+        if configpath.endswith('.json'):
+            config_data = json.load(configfile)
+        elif configpath.endswith('.yaml') or configpath.endswith('.yml'):
+            config_data = yaml.load(configfile, Loader=yaml.FullLoader)
+        else:
+            raise ValueError("Unsupported file format. Please provide a .json or .yaml file.")
         return config_data
 
 def setup_logger(name, log_path=None):

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -257,7 +257,9 @@ def analysis_main(args, output, runnormal=False, normalname=False, normalfastqs=
         
         # copying configfiles to analysisdir
         clusterconf = config["clusterconf"]
+        filterconf = config["filterconf"]
         copyfile(f"{configdir}/{clusterconf}", f"{runconfigs}/{clusterconf}")
+        copyfile(f"{configdir}/{filterconf}", f"{runconfigs}/{filterconf}")
         copyfile(f"{configdir}/{mainconf_name}", f"{runconfigs}/{mainconf_name}")
         if tumorname:
             samplelog = f"{samplelogs}/{tumorid}.log"

--- a/pipeline.snakefile
+++ b/pipeline.snakefile
@@ -37,7 +37,8 @@ else:
 
 
 pipeconfig = helpers.read_config(configfilepath)
-clusterconf = helpers.read_clusterconf()
+clusterconf = helpers.read_config(f"{ROOT_DIR}/configs/cluster.yaml")
+filterconfig = helpers.read_config(f"{ROOT_DIR}/configs/filterts.")
 
 shell.executable("/bin/bash")
 

--- a/pipeline.snakefile
+++ b/pipeline.snakefile
@@ -110,13 +110,13 @@ if tumorfastqdirs:
 if tumorid:
     if normalid:
         # Runs tn_workflow / paired if tumorid and normalid
-        localrules: all, upload_to_iva, tn_workflow, share_to_resultdir, excel_qc
+        localrules: all, upload_to_iva, tn_workflow, share_to_resultdir, excel_qc, tmb_calculation
     else:
         # Runs tumoronly_workflow if tumorid but not normalid
-        localrules: all, upload_to_iva, share_to_resultdir, excel_qc, tumoronly_workflow
+        localrules: all, upload_to_iva, tumoronly_workflow, share_to_resultdir, excel_qc, tmb_calculation
 else: 
     # Runs normalonly_workflow if normalid but not tumorid
-    localrules: all, upload_to_iva, share_to_resultdir, excel_qc, normalonly_workflow
+    localrules: all, upload_to_iva, normalonly_workflow, share_to_resultdir, excel_qc
 ###########################################################
 
 ########################################
@@ -134,6 +134,7 @@ else:
 if tumorid:
     include:        "workflows/rules/variantcalling/tnscope.smk"
     include:        "workflows/rules/variantcalling/pindel.smk"
+    include:        "workflows/rules/small_tools/tmb_calculation.smk"
 include:        "workflows/rules/variantcalling/dnascope.smk"
 include:        "workflows/rules/small_tools/ballele.smk"
 include:        "workflows/rules/variantcalling/canvas.smk"

--- a/pipeline.snakefile
+++ b/pipeline.snakefile
@@ -38,7 +38,7 @@ else:
 
 pipeconfig = helpers.read_config(configfilepath)
 clusterconf = helpers.read_config(f"{ROOT_DIR}/configs/cluster.yaml")
-filterconfig = helpers.read_config(f"{ROOT_DIR}/configs/filterts.")
+filterconfig = helpers.read_config(f"{ROOT_DIR}/configs/filters.yaml")
 
 shell.executable("/bin/bash")
 

--- a/tnscope_eval.snakefile
+++ b/tnscope_eval.snakefile
@@ -42,7 +42,7 @@ configfilepath = f"{ROOT_DIR}/configs/config_hg38.json"
 
 
 pipeconfig = helpers.read_config(configfilepath)
-clusterconf = helpers.read_clusterconf()
+clusterconf = helpers.read_config(f"{ROOT_DIR}/configs/cluster.yaml")
 
 shell.executable("/bin/bash")
 

--- a/workflows/rules/qc/aggregate_qc.smk
+++ b/workflows/rules/qc/aggregate_qc.smk
@@ -18,12 +18,13 @@ if tumorid:
                 normalvcf = expand("{stype}/dnascope/{sname}_germline_SNVsOnly.recode.vcf", stype=sampleconfig[normalname]["stype"], sname=normalid),
                 canvasvcf = expand("{stype}/canvas/{sname}_CNV_somatic.vcf", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
                 insilicofile = expand("{stype}/insilico/{insiliconame}/{sname}_{insiliconame}_genes_below10x.xlsx", stype=sampleconfig[normalname]["stype"], insiliconame=sampleconfig["insilico"], sname=normalid),
+                tmb = expand("{stype}/reports/{sname}_tmb.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid)
             output:
                 temp("qc_report/{tumorname}_qc_stats.xlsx")
             run:
                 my_insilicofile = f"{input.insilicofile}".split(" ", 1)[0]
                 insilicodir = os.path.dirname(f"{my_insilicofile}").rsplit("/", 1)[0] # Somehow this stuff works
-                create_excel_main(tumorcov = f"{input.tumorcov}", ycov = f"{input.ycov}" , normalcov = f"{input.normalcov}", tumordedup = f"{input.tumordedup}", normaldedup = f"{input.normaldedup}", tumorvcf = f"{input.tumorvcf}", normalvcf = f"{input.normalvcf}", canvasvcf = f"{input.canvasvcf}", output = f"{output}", insilicodir = f"{insilicodir}") 
+                create_excel_main(tumorcov = f"{input.tumorcov}", ycov = f"{input.ycov}" , normalcov = f"{input.normalcov}", tumordedup = f"{input.tumordedup}", normaldedup = f"{input.normaldedup}", tumorvcf = f"{input.tumorvcf}", normalvcf = f"{input.normalvcf}", canvasvcf = f"{input.canvasvcf}", tmb = f"{input.tmb}", output = f"{output}", insilicodir = f"{insilicodir}") 
     else:
         # excel_qc rule for tumor only
         rule excel_qc:
@@ -33,12 +34,13 @@ if tumorid:
                 tumordedup = expand("{stype}/dedup/{sname}_DEDUP.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
                 tumorvcf = expand("{stype}/dnascope/{sname}_germline_SNVsOnly.recode.vcf", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
                 insilicofile = expand("{stype}/insilico/{insiliconame}/{sname}_{insiliconame}_genes_below10x.xlsx", stype=sampleconfig[tumorname]["stype"], insiliconame=sampleconfig["insilico"], sname=tumorid),
+                tmb = expand("{stype}/reports/{sname}_tmb.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid)
             output:
                 temp("qc_report/{tumorname}_qc_stats.xlsx")
             run:
                 my_insilicofile = f"{input.insilicofile}".split(" ", 1)[0]
                 insilicodir = os.path.dirname(f"{my_insilicofile}").rsplit("/", 1)[0] # Somehow this stuff works
-                create_excel_main(tumorcov = f"{input.tumorcov}", ycov = f"{input.ycov}", tumordedup = f"{input.tumordedup}", tumorvcf = f"{input.tumorvcf}", output = f"{output}", insilicodir = f"{insilicodir}")
+                create_excel_main(tumorcov = f"{input.tumorcov}", ycov = f"{input.ycov}", tumordedup = f"{input.tumordedup}", tumorvcf = f"{input.tumorvcf}", tmb = f"{input.tmb}", output = f"{output}", insilicodir = f"{insilicodir}")
 
 else:
     # excel_qc rule for normal only

--- a/workflows/rules/results_sharing/upload_to_iva.smk
+++ b/workflows/rules/results_sharing/upload_to_iva.smk
@@ -1,7 +1,7 @@
 # vim: syntax=python tabstop=4 expandtab
 # coding: utf-8
 import os
-from helpers import read_passconfig
+from helpers import read_config
 from shutil import copyfile
 
 rule filter_variants_in_bed:
@@ -42,7 +42,7 @@ rule upload_to_iva:
     run:
         # copy to clc accessible directory
         vcfbase = os.path.basename(f"{input}")
-        passconfig = read_passconfig()
+        passconfig = read_config("/root/password_config.json")
         clcpass = passconfig["clcpass"]
         ivapass = passconfig[ivauser]["ivapass"]
         ivaemail = passconfig[ivauser]["ivauser"]
@@ -82,7 +82,7 @@ rule upload_to_iva_test:
     run:
         # copy to clc accessible directory
         vcfbase = os.path.basename(f"{input}")
-        passconfig = read_passconfig()
+        passconfig = read_config("/root/password_config.json")
         clcpass = passconfig["clcpass"]
         ivapass = passconfig[ivauser]["ivapass"]
         ivaemail = passconfig[ivauser]["ivauser"]

--- a/workflows/rules/small_tools/tmb_calculation.smk
+++ b/workflows/rules/small_tools/tmb_calculation.smk
@@ -4,7 +4,7 @@ if normalid:
             somatic_n = "{stype}/tnscope/{sname}_somatic_w_normal.vcf"
         params:
             bcftools = pipeconfig["rules"]["tmb_calculation"]["bcftools"],
-            genome_size = pipeconfig["rules"]["tmb_calculation"]["genome_size"],
+            effective_genome_size = pipeconfig["rules"]["tmb_calculation"]["effective_genome_size"],
             min_mutant_allele_fraction = filterconfig["tmb_filter"]["min_mutant_allele_fraction"],
             min_mutant_allele_reads = filterconfig["tmb_filter"]["min_mutant_allele_reads"],
             min_coverage = filterconfig["tmb_filter"]["min_coverage"],
@@ -16,13 +16,13 @@ if normalid:
                 f"&& FORMAT/AD[0:1]>{params.min_mutant_allele_reads} "
                 f"&& FORMAT/AFDP[0,1]>{params.min_coverage}' {input.somatic_n} | "
                 f"{params.bcftools} stats | grep 'number of records:' | awk '{{{{print $NF}}}}' | "
-                f"awk -v genome_size={params.genome_size} '{{{{ printf \"TMB\\t%.2f\\n\", ($1 / genome_size * 1e6) }}}}' > {output.tmb}"
+                f"awk -v gsize={params.effective_genome_size} '{{{{ printf \"TMB\\t%.2f\\n\", ($1 / gsize * 1e6) }}}}' > {output.tmb}"
             )
             add_parameters = (
                 f"echo -e 'min_mutant_allele_fraction\\t{params.min_mutant_allele_fraction}\\n"
                 f"min_mutant_allele_reads\\t{params.min_mutant_allele_reads}\\n"
                 f"min_coverage\\t{params.min_coverage}\\n"
-                f"effective_genome_size\\t{params.genome_size}' >> {output.tmb}"
+                f"effective_genome_size\\t{params.effective_genome_size}' >> {output.tmb}"
             )
             print(shell_command)
             shell(shell_command)
@@ -34,7 +34,7 @@ else:
             somatic = "{stype}/tnscope/{sname}_somatic.vcf"
         params:
             bcftools = pipeconfig["rules"]["tmb_calculation"]["bcftools"],
-            genome_size = pipeconfig["rules"]["tmb_calculation"]["genome_size"],
+            effective_genome_size = pipeconfig["rules"]["tmb_calculation"]["effective_genome_size"],
             min_mutant_allele_fraction = filterconfig["tmb_filter"]["min_mutant_allele_fraction"],
             min_mutant_allele_reads = filterconfig["tmb_filter"]["min_mutant_allele_reads"],
             min_coverage = filterconfig["tmb_filter"]["min_coverage"],
@@ -46,13 +46,13 @@ else:
                 f"&& FORMAT/AD[0:1]>{params.min_mutant_allele_reads} "
                 f"&& FORMAT/AFDP[0]>{params.min_coverage}' {input.somatic} | "  # Note, here we only use the first sample
                 f"{params.bcftools} stats | grep 'number of records:' | awk '{{{{print $NF}}}}' | "
-                f"awk -v genome_size={params.genome_size} '{{{{ printf \"TMB\\t%.2f\\n\", ($1 / genome_size * 1e6) }}}}' > {output.tmb}"
+                f"awk -v gsize={params.effective_genome_size} '{{{{ printf \"TMB\\t%.2f\\n\", ($1 / gsize * 1e6) }}}}' > {output.tmb}"
             )
             add_parameters = (
                 f"echo -e 'min_mutant_allele_fraction\\t{params.min_mutant_allele_fraction}\\n"
                 f"min_mutant_allele_reads\\t{params.min_mutant_allele_reads}\\n"
                 f"min_coverage\\t{params.min_coverage}\\n"
-                f"effective_genome_size\\t{params.genome_size}' >> {output.tmb}"
+                f"effective_genome_size\\t{params.effective_genome_size}' >> {output.tmb}"
             )
             print(shell_command)
             shell(shell_command)

--- a/workflows/rules/small_tools/tmb_calculation.smk
+++ b/workflows/rules/small_tools/tmb_calculation.smk
@@ -4,14 +4,19 @@ if normalid:
             somatic_n = "{stype}/tnscope/{sname}_somatic_w_normal.vcf"
         params:
             bcftools = pipeconfig["rules"]["tmb_calculation"]["bcftools"],
-            genome_size = pipeconfig["rules"]["tmb_calculation"]["genome_size"]
+            genome_size = pipeconfig["rules"]["tmb_calculation"]["genome_size"],
+            min_mutant_allele_fraction = filterconfig["tmb_filter"]["min_mutant_allele_fraction"],
+            min_mutant_allele_reads = filterconfig["tmb_filter"]["min_mutant_allele_reads"],
+            min_coverage = filterconfig["tmb_filter"]["min_coverage"],
         output:
             tmb = temp("{stype}/reports/{sname}_tmb.txt"),
         run:
             shell_command = (
-                f"{params.bcftools} filter -i 'FORMAT/AF[0]>0.05 && FORMAT/AD[0:1]>3 && FORMAT/AFDP[0,1]>10' {input.somatic_n} | "
-                f"{params.bcftools} query -f '%POS\\n' | wc -l | "
-                f"awk -v genome_size={params.genome_size} '{{{{ printf \"%.2f\", ($0 / genome_size * 1e6) }}}}' > {output.tmb}"
+                f"{params.bcftools} filter -i 'FORMAT/AF[0]>{params.min_mutant_allele_fraction} "
+                f"&& FORMAT/AD[0:1]>{params.min_mutant_allele_reads} "
+                f"&& FORMAT/AFDP[0,1]>{params.min_coverage}' {input.somatic_n} | "
+                f"{params.bcftools} stats | grep 'number of records:' | awk '{{{{print $NF}}}}' | "
+                f"awk -v genome_size={params.genome_size} '{{{{ printf \"%.2f\", ($1 / genome_size * 1e6) }}}}' > {output.tmb}"
             )
             print(shell_command)
             shell(shell_command)
@@ -22,14 +27,19 @@ else:
             somatic = "{stype}/tnscope/{sname}_somatic.vcf"
         params:
             bcftools = pipeconfig["rules"]["tmb_calculation"]["bcftools"],
-            genome_size = pipeconfig["rules"]["tmb_calculation"]["genome_size"]
+            genome_size = pipeconfig["rules"]["tmb_calculation"]["genome_size"],
+            min_mutant_allele_fraction = filterconfig["tmb_filter"]["min_mutant_allele_fraction"],
+            min_mutant_allele_reads = filterconfig["tmb_filter"]["min_mutant_allele_reads"],
+            min_coverage = filterconfig["tmb_filter"]["min_coverage"],
         output:
             tmb = temp("{stype}/reports/{sname}_tmb.txt"),
         run:
             shell_command = (
-                f"{params.bcftools} filter -i 'FORMAT/AF[0]>0.05 && FORMAT/AD[0:1]>3 && FORMAT/AFDP[0]>10' {input.somatic} | "
-                f"{params.bcftools} query -f '%POS\\n' | wc -l | "
-                f"awk -v genome_size={params.genome_size} '{{{{ printf \"%.2f\", ($0 / genome_size * 1e6) }}}}' > {output.tmb}"
+                f"{params.bcftools} filter -i 'FORMAT/AF[0]>{params.min_mutant_allele_fraction} "
+                f"&& FORMAT/AD[0:1]>{params.min_mutant_allele_reads} "
+                f"&& FORMAT/AFDP[0]>{params.min_coverage}' {input.somatic} | "  # Note, here we only use the first sample
+                f"{params.bcftools} stats | grep 'number of records:' | awk '{{{{print $NF}}}}' | "
+                f"awk -v genome_size={params.genome_size} '{{{{ printf \"%.2f\", ($1 / genome_size * 1e6) }}}}' > {output.tmb}"
             )
             print(shell_command)
             shell(shell_command)

--- a/workflows/rules/small_tools/tmb_calculation.smk
+++ b/workflows/rules/small_tools/tmb_calculation.smk
@@ -1,0 +1,39 @@
+if normalid:
+    rule tmb_calculation:
+        input:
+            somatic_n = "{stype}/tnscope/{sname}_somatic_w_normal.vcf"
+        params:
+            bcftools = pipeconfig["rules"]["tmb_calculation"]["bcftools"],
+            genome_size = pipeconfig["rules"]["tmb_calculation"]["genome_size"]
+        output:
+            tmb = temp("{stype}/reports/{sname}_tmb.txt"),
+        run:
+            shell_command = (
+                f"{params.bcftools} filter -i '"
+                "FORMAT/AF[0]>0.05 && FORMAT/AD[0:1]>3 "  # mutant allele frequency > 5% and mutant allele depth > 3
+                f"&& FORMAT/AFDP[0,1]>10' {input.somatic_n} | "  # overall depth > 10 in both normal and tumor
+                f"{params.bcftools} stats | grep 'number of records:' | awk '{{print $NF}}' | "
+                f"awk -v genome_size={params.genome_size} '{{ printf '%.2f' ($1 / genome_size * 1e6) }}' > {output.tmb}"
+            )
+            print(shell_command)
+            shell(shell_command)
+
+else:
+    rule tmb_calculation:
+        input:
+            somatic = "{stype}/tnscope/{sname}_somatic.vcf"
+        params:
+            bcftools = pipeconfig["rules"]["tmb_calculation"]["bcftools"],
+            genome_size = pipeconfig["rules"]["tmb_calculation"]["genome_size"]
+        output:
+            tmb = temp("{stype}/reports/{sname}_tmb.txt"),
+        run:
+            shell_command = (
+                f"{params.bcftools} filter -i '"
+                "FORMAT/AF[0]>0.05 && FORMAT/AD[0:1]>3 "  # mutant allele frequency > 5% and mutant allele depth > 3
+                f"&& FORMAT/AFDP[0]>10' {input.somatic} | "  # overall depth > 10 in tumor
+                f"{params.bcftools} stats | grep 'number of records:' | awk '{{print $NF}}' | "
+                f"awk -v genome_size={params.genome_size} '{{ printf '%.2f' ($1 / genome_size * 1e6) }}' > {output.tmb}"
+            )
+            print(shell_command)
+            shell(shell_command)

--- a/workflows/rules/small_tools/tmb_calculation.smk
+++ b/workflows/rules/small_tools/tmb_calculation.smk
@@ -1,59 +1,25 @@
-if normalid:
-    rule tmb_calculation:
-        input:
-            somatic_n = "{stype}/tnscope/{sname}_somatic_w_normal.vcf"
-        params:
-            bcftools = pipeconfig["rules"]["tmb_calculation"]["bcftools"],
-            effective_genome_size = pipeconfig["rules"]["tmb_calculation"]["effective_genome_size"],
-            min_mutant_allele_fraction = filterconfig["tmb_filter"]["min_mutant_allele_fraction"],
-            min_mutant_allele_reads = filterconfig["tmb_filter"]["min_mutant_allele_reads"],
-            min_coverage = filterconfig["tmb_filter"]["min_coverage"],
-        output:
-            tmb = temp("{stype}/reports/{sname}_tmb.txt"),
-        run:
-            shell_command = (
-                f"{params.bcftools} filter -i 'FORMAT/AF[0]>{params.min_mutant_allele_fraction} "
-                f"&& FORMAT/AD[0:1]>{params.min_mutant_allele_reads} "
-                f"&& FORMAT/AFDP[0,1]>{params.min_coverage}' {input.somatic_n} | "
-                f"{params.bcftools} stats | grep 'number of records:' | awk '{{{{print $NF}}}}' | "
-                f"awk -v gsize={params.effective_genome_size} '{{{{ printf \"TMB\\t%.2f\\n\", ($1 / gsize * 1e6) }}}}' > {output.tmb}"
-            )
-            add_parameters = (
-                f"echo -e 'min_mutant_allele_fraction\\t{params.min_mutant_allele_fraction}\\n"
-                f"min_mutant_allele_reads\\t{params.min_mutant_allele_reads}\\n"
-                f"min_coverage\\t{params.min_coverage}\\n"
-                f"effective_genome_size\\t{params.effective_genome_size}' >> {output.tmb}"
-            )
-            print(shell_command)
-            shell(shell_command)
-            shell(add_parameters)
-
-else:
-    rule tmb_calculation:
-        input:
-            somatic = "{stype}/tnscope/{sname}_somatic.vcf"
-        params:
-            bcftools = pipeconfig["rules"]["tmb_calculation"]["bcftools"],
-            effective_genome_size = pipeconfig["rules"]["tmb_calculation"]["effective_genome_size"],
-            min_mutant_allele_fraction = filterconfig["tmb_filter"]["min_mutant_allele_fraction"],
-            min_mutant_allele_reads = filterconfig["tmb_filter"]["min_mutant_allele_reads"],
-            min_coverage = filterconfig["tmb_filter"]["min_coverage"],
-        output:
-            tmb = temp("{stype}/reports/{sname}_tmb.txt"),
-        run:
-            shell_command = (
-                f"{params.bcftools} filter -i 'FORMAT/AF[0]>{params.min_mutant_allele_fraction} "
-                f"&& FORMAT/AD[0:1]>{params.min_mutant_allele_reads} "
-                f"&& FORMAT/AFDP[0]>{params.min_coverage}' {input.somatic} | "  # Note, here we only use the first sample
-                f"{params.bcftools} stats | grep 'number of records:' | awk '{{{{print $NF}}}}' | "
-                f"awk -v gsize={params.effective_genome_size} '{{{{ printf \"TMB\\t%.2f\\n\", ($1 / gsize * 1e6) }}}}' > {output.tmb}"
-            )
-            add_parameters = (
-                f"echo -e 'min_mutant_allele_fraction\\t{params.min_mutant_allele_fraction}\\n"
-                f"min_mutant_allele_reads\\t{params.min_mutant_allele_reads}\\n"
-                f"min_coverage\\t{params.min_coverage}\\n"
-                f"effective_genome_size\\t{params.effective_genome_size}' >> {output.tmb}"
-            )
-            print(shell_command)
-            shell(shell_command)
-            shell(add_parameters)
+rule tmb_calculation:
+    input:
+        somatic_vcf = "{stype}/tnscope/{sname}_somatic_w_normal.vcf"
+    params:
+        calculate_tmb = os.path.join(workflow.basedir, "workflows/scripts/calculate_tmb.sh"),
+        bcftools = pipeconfig["rules"]["tmb_calculation"]["bcftools"],
+        effective_genome_size = pipeconfig["rules"]["tmb_calculation"]["effective_genome_size"],
+        min_mutant_allele_fraction = filterconfig["tmb_filter"]["min_mutant_allele_fraction"],
+        min_mutant_allele_reads = filterconfig["tmb_filter"]["min_mutant_allele_reads"],
+        min_coverage = filterconfig["tmb_filter"]["min_coverage"],
+        include_normal = ("True" if normalid else "False"),
+    output:
+        tmb = temp("{stype}/reports/{sname}_tmb.txt"),
+    shell:
+        """
+        bash {params.calculate_tmb} \
+        {params.bcftools} \
+        {input.somatic_vcf} \
+        {params.effective_genome_size} \
+        {params.min_mutant_allele_fraction} \
+        {params.min_mutant_allele_reads} \
+        {params.min_coverage} \
+        {output.tmb} \
+        {params.include_normal}
+        """

--- a/workflows/rules/small_tools/tmb_calculation.smk
+++ b/workflows/rules/small_tools/tmb_calculation.smk
@@ -9,11 +9,9 @@ if normalid:
             tmb = temp("{stype}/reports/{sname}_tmb.txt"),
         run:
             shell_command = (
-                f"{params.bcftools} filter -i '"
-                "FORMAT/AF[0]>0.05 && FORMAT/AD[0:1]>3 "  # mutant allele frequency > 5% and mutant allele depth > 3
-                f"&& FORMAT/AFDP[0,1]>10' {input.somatic_n} | "  # overall depth > 10 in both normal and tumor
-                f"{params.bcftools} stats | grep 'number of records:' | awk '{{print $NF}}' | "
-                f"awk -v genome_size={params.genome_size} '{{ printf '%.2f' ($1 / genome_size * 1e6) }}' > {output.tmb}"
+                f"{params.bcftools} filter -i 'FORMAT/AF[0]>0.05 && FORMAT/AD[0:1]>3 && FORMAT/AFDP[0,1]>10' {input.somatic_n} | "
+                f"{params.bcftools} query -f '%POS\\n' | wc -l | "
+                f"awk -v genome_size={params.genome_size} '{{{{ printf \"%.2f\", ($0 / genome_size * 1e6) }}}}' > {output.tmb}"
             )
             print(shell_command)
             shell(shell_command)
@@ -29,11 +27,9 @@ else:
             tmb = temp("{stype}/reports/{sname}_tmb.txt"),
         run:
             shell_command = (
-                f"{params.bcftools} filter -i '"
-                "FORMAT/AF[0]>0.05 && FORMAT/AD[0:1]>3 "  # mutant allele frequency > 5% and mutant allele depth > 3
-                f"&& FORMAT/AFDP[0]>10' {input.somatic} | "  # overall depth > 10 in tumor
-                f"{params.bcftools} stats | grep 'number of records:' | awk '{{print $NF}}' | "
-                f"awk -v genome_size={params.genome_size} '{{ printf '%.2f' ($1 / genome_size * 1e6) }}' > {output.tmb}"
+                f"{params.bcftools} filter -i 'FORMAT/AF[0]>0.05 && FORMAT/AD[0:1]>3 && FORMAT/AFDP[0]>10' {input.somatic} | "
+                f"{params.bcftools} query -f '%POS\\n' | wc -l | "
+                f"awk -v genome_size={params.genome_size} '{{{{ printf \"%.2f\", ($0 / genome_size * 1e6) }}}}' > {output.tmb}"
             )
             print(shell_command)
             shell(shell_command)

--- a/workflows/rules/small_tools/tmb_calculation.smk
+++ b/workflows/rules/small_tools/tmb_calculation.smk
@@ -16,10 +16,17 @@ if normalid:
                 f"&& FORMAT/AD[0:1]>{params.min_mutant_allele_reads} "
                 f"&& FORMAT/AFDP[0,1]>{params.min_coverage}' {input.somatic_n} | "
                 f"{params.bcftools} stats | grep 'number of records:' | awk '{{{{print $NF}}}}' | "
-                f"awk -v genome_size={params.genome_size} '{{{{ printf \"%.2f\", ($1 / genome_size * 1e6) }}}}' > {output.tmb}"
+                f"awk -v genome_size={params.genome_size} '{{{{ printf \"TMB\\t%.2f\\n\", ($1 / genome_size * 1e6) }}}}' > {output.tmb}"
+            )
+            add_parameters = (
+                f"echo -e 'min_mutant_allele_fraction\\t{params.min_mutant_allele_fraction}\\n"
+                f"min_mutant_allele_reads\\t{params.min_mutant_allele_reads}\\n"
+                f"min_coverage\\t{params.min_coverage}\\n"
+                f"effective_genome_size\\t{params.genome_size}' >> {output.tmb}"
             )
             print(shell_command)
             shell(shell_command)
+            shell(add_parameters)
 
 else:
     rule tmb_calculation:
@@ -39,7 +46,14 @@ else:
                 f"&& FORMAT/AD[0:1]>{params.min_mutant_allele_reads} "
                 f"&& FORMAT/AFDP[0]>{params.min_coverage}' {input.somatic} | "  # Note, here we only use the first sample
                 f"{params.bcftools} stats | grep 'number of records:' | awk '{{{{print $NF}}}}' | "
-                f"awk -v genome_size={params.genome_size} '{{{{ printf \"%.2f\", ($1 / genome_size * 1e6) }}}}' > {output.tmb}"
+                f"awk -v genome_size={params.genome_size} '{{{{ printf \"TMB\\t%.2f\\n\", ($1 / genome_size * 1e6) }}}}' > {output.tmb}"
+            )
+            add_parameters = (
+                f"echo -e 'min_mutant_allele_fraction\\t{params.min_mutant_allele_fraction}\\n"
+                f"min_mutant_allele_reads\\t{params.min_mutant_allele_reads}\\n"
+                f"min_coverage\\t{params.min_coverage}\\n"
+                f"effective_genome_size\\t{params.genome_size}' >> {output.tmb}"
             )
             print(shell_command)
             shell(shell_command)
+            shell(add_parameters)

--- a/workflows/scripts/calculate_tmb.sh
+++ b/workflows/scripts/calculate_tmb.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Input arguments
+bcftools=$1
+input_vcf=$2
+genome_size=$3
+min_mutant_allele_fraction=$4
+min_mutant_allele_reads=$5
+min_coverage=$6
+output_file=$7
+include_normal=$8
+
+# Determine the FORMAT/AFDP value based on include_normalid
+if [ "$include_normal" == "True" ]; then
+    filt_norm="&& FORMAT/AFDP[1]>$min_coverage"  # Include both tumor and normal
+else
+    filt_norm=""  # Only include tumor
+fi
+
+# Run the bcftools and awk commands
+$bcftools filter -i "FORMAT/AF[0]>$min_mutant_allele_fraction && FORMAT/AD[0:1]>$min_mutant_allele_reads && FORMAT/AFDP[0]>$min_coverage $filt_norm" $input_vcf | \
+$bcftools stats | grep 'number of records:' | awk '{print $NF}' | \
+awk -v gsize=$genome_size '{ printf "TMB\t%.2f\n", ($1 / gsize * 1e6) }' > $output_file
+
+# Add parameters to the output file
+echo -e "min_mutant_allele_fraction\t$min_mutant_allele_fraction" >> $output_file
+echo -e "min_mutant_allele_reads\t$min_mutant_allele_reads"  >> $output_file
+echo -e "min_coverage\t$min_coverage"  >> $output_file
+echo -e "effective_genome_size\t$genome_size" >> $output_file

--- a/workflows/scripts/calculate_tmb.sh
+++ b/workflows/scripts/calculate_tmb.sh
@@ -10,17 +10,17 @@ min_coverage=$6
 output_file=$7
 include_normal=$8
 
-# Determine the FORMAT/AFDP value based on include_normalid
+# Adjust coverage filtering based on include_normal parameter
 if [ "$include_normal" == "True" ]; then
-    filt_norm="&& FORMAT/AFDP[1]>$min_coverage"  # Include both tumor and normal
+    filt_norm="&& FORMAT/AFDP[1]>$min_coverage"  # Include normal in coverage filter
 else
-    filt_norm=""  # Only include tumor
+    filt_norm=""  # Only use the tumor sample in coverage filter
 fi
 
 # Run the bcftools and awk commands
-$bcftools filter -i "FORMAT/AF[0]>$min_mutant_allele_fraction && FORMAT/AD[0:1]>$min_mutant_allele_reads && FORMAT/AFDP[0]>$min_coverage $filt_norm" $input_vcf | \
-$bcftools stats | grep 'number of records:' | awk '{print $NF}' | \
-awk -v gsize=$genome_size '{ printf "TMB\t%.2f\n", ($1 / gsize * 1e6) }' > $output_file
+$bcftools filter -i "FORMAT/AF[0]>$min_mutant_allele_fraction && FORMAT/AD[0:1]>$min_mutant_allele_reads && FORMAT/AFDP[0]>$min_coverage $filt_norm" $input_vcf | \  # Filter the VCF file
+$bcftools stats | grep 'number of records:' | awk '{print $NF}' | \  # Get the total number of mutation post filtering
+awk -v gsize=$genome_size '{ printf "TMB\t%.2f\n", ($1 / gsize * 1e6) }' > $output_file  # Calculate the TMB and write to the output file
 
 # Add parameters to the output file
 echo -e "min_mutant_allele_fraction\t$min_mutant_allele_fraction" >> $output_file

--- a/workflows/scripts/create_qc_excel.py
+++ b/workflows/scripts/create_qc_excel.py
@@ -88,8 +88,17 @@ def get_canvas_tumorinfo(canvasvcf):
                     canvasdict[canvasfield] = canvasfield_value
     return canvasdict
 
+def read_tmb(tmbfile):
+    try:
+        with open(tmbfile, 'r') as tmb:
+            tmb_val = int(tmb.read().rstrip())
+            return tmb_val
+    except FileNotFoundError:
+        return "No TMB file found"
+    except ValueError:
+        return "Invalid TMB value"
 
-def create_excel(statsdict, output, normalname, tumorname, match_dict, canvasdict, sex):
+def create_excel(statsdict, output, normalname, tumorname, match_dict, canvasdict, sex, tmb_val):
     current_date = time.strftime("%Y-%m-%d")
     excelfile = xlsxwriter.Workbook(output)
     worksheet = excelfile.add_worksheet("qc_stats")
@@ -194,10 +203,14 @@ def create_excel(statsdict, output, normalname, tumorname, match_dict, canvasdic
             worksheet.write(row, 1, canvasdict[key])
             row += 1
 
+    row += 1
+    worksheet.write(row, 0, "TMB:", cellformat["section"])
+    worksheet.write(row, 1, tmb_val)
+
     excelfile.close()
 
 
-def create_excel_main(tumorcov='', ycov='', normalcov='', tumordedup='', normaldedup='', tumorvcf='', normalvcf='', canvasvcf='', output='', insilicodir=''):
+def create_excel_main(tumorcov='', ycov='', normalcov='', tumordedup='', normaldedup='', tumorvcf='', normalvcf='', canvasvcf='', tmb='', output='', insilicodir=''):
     print(f"insilicodir: {insilicodir}")
     statsdict = {}
     if tumorcov:
@@ -205,6 +218,7 @@ def create_excel_main(tumorcov='', ycov='', normalcov='', tumordedup='', normald
         tumorname = tumorcovfile.replace("_WGScov.tsv", "")
         statsdict = extract_stats(tumorcov, "coverage",  "tumor", statsdict)
         statsdict = extract_stats(tumordedup, "dedup",  "tumor", statsdict)
+        tmb_val = read_tmb(tmb)
     if normalcov:
         normalcovfile = os.path.basename(normalcov)
         normalname = normalcovfile.replace("_WGScov.tsv", "")
@@ -226,17 +240,17 @@ def create_excel_main(tumorcov='', ycov='', normalcov='', tumordedup='', normald
         if normalcov:
             # Tumour + Normal
             calculated_sex = calc_sex(normalcov, ycov)
-            create_excel(statsdict, output, normalname, tumorname, match_dict, canvas_dict, sex=calculated_sex)
+            create_excel(statsdict, output, normalname, tumorname, match_dict, canvas_dict, sex=calculated_sex, tmb=tmb_val)
             add_insilico_stats(insilicodir, output)
         else:
             # Tumour only
             calculated_sex = calc_sex(tumorcov, ycov)
-            create_excel(statsdict, output, normalname='', tumorname=tumorname, match_dict='', canvasdict='', sex=calculated_sex)
+            create_excel(statsdict, output, normalname='', tumorname=tumorname, match_dict='', canvasdict='', sex=calculated_sex, tmb=tmb_val)
             add_insilico_stats(insilicodir, output) # Maybe this can be commented out if not needed for tumour only
     else:
         # Normal only
         calculated_sex = calc_sex(normalcov, ycov)
-        create_excel(statsdict, output, normalname, tumorname='', match_dict='', canvasdict='', sex=calculated_sex)
+        create_excel(statsdict, output, normalname, tumorname='', match_dict='', canvasdict='', sex=calculated_sex, tmb='')
         add_insilico_stats(insilicodir, output)
 
 if __name__ == '__main__':
@@ -250,6 +264,7 @@ if __name__ == '__main__':
     parser.add_argument('-nv', '--normalvcf', nargs='?', help='Normal Germlinecalls', required=True)
     parser.add_argument('-cv', '--canvasvcf', nargs='?', help='Somatic Canvas VCF', required=False)
     parser.add_argument('-is', '--insilicodir', nargs='?', help='Full path to insilico directory (which contains excel files)', required=False)
+    parser.add_argument('--tmb', nargs='?', help='TMB file', required=False)
     parser.add_argument('-o', '--output', nargs='?', help='fullpath to file to be created (xlsx will be appended if not written)', required=True)
     args = parser.parse_args()
     create_excel_main(args.tumorcov, args.ycov, args.normalcov, args.tumordedup, args.normaldedup, args.tumorvcf, args.normalvcf, args.canvasvcf, args.output, args.insilicodir)

--- a/workflows/scripts/create_qc_excel.py
+++ b/workflows/scripts/create_qc_excel.py
@@ -91,8 +91,8 @@ def get_canvas_tumorinfo(canvasvcf):
 def read_tmb(tmbfile):
     try:
         with open(tmbfile, 'r') as tmb:
-            tmb_val = int(tmb.read().rstrip())
-            return tmb_val
+            tmb_val = tmb.read().strip()
+            return float(tmb_val)
     except FileNotFoundError:
         return "No TMB file found"
     except ValueError:
@@ -240,17 +240,17 @@ def create_excel_main(tumorcov='', ycov='', normalcov='', tumordedup='', normald
         if normalcov:
             # Tumour + Normal
             calculated_sex = calc_sex(normalcov, ycov)
-            create_excel(statsdict, output, normalname, tumorname, match_dict, canvas_dict, sex=calculated_sex, tmb=tmb_val)
+            create_excel(statsdict, output, normalname, tumorname, match_dict, canvas_dict, sex=calculated_sex, tmb_val=tmb_val)
             add_insilico_stats(insilicodir, output)
         else:
             # Tumour only
             calculated_sex = calc_sex(tumorcov, ycov)
-            create_excel(statsdict, output, normalname='', tumorname=tumorname, match_dict='', canvasdict='', sex=calculated_sex, tmb=tmb_val)
+            create_excel(statsdict, output, normalname='', tumorname=tumorname, match_dict='', canvasdict='', sex=calculated_sex, tmb_val=tmb_val)
             add_insilico_stats(insilicodir, output) # Maybe this can be commented out if not needed for tumour only
     else:
         # Normal only
         calculated_sex = calc_sex(normalcov, ycov)
-        create_excel(statsdict, output, normalname, tumorname='', match_dict='', canvasdict='', sex=calculated_sex, tmb='')
+        create_excel(statsdict, output, normalname, tumorname='', match_dict='', canvasdict='', sex=calculated_sex, tmb_val='')
         add_insilico_stats(insilicodir, output)
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Contents

### The What

Added tumor mutation burden (TMB) calculation to the wgs-somatic pipeline and added the output to the qc_excel file. It will be mainly useful for the tumor-normal runs, but I have added it to the tumor-only runs as well (the TMB will be several folds higher).

### The Why

The geneticists would like TMB for their analyses

### The How

Filtered the somatic tumor (and normal) vcf file from TNscope with bcftools. The filters are decided based on [Tesi et al 2024](https://doi.org/10.1200/PO.23.00039). The filters can be changed in the filters.yaml config file, and will be added to the final output. 

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ x ] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure

Tested the pipeline with a tumor-normal and tumor-only run

## Verifications
- [ x ] Code reviewed by @Bart-Edelbroek 
- [ x ] Code tested by @Bart-Edelbroek 
