### PR TITLE
default department to None if none found in slims

### DIFF
--- a/tools/slims.py
+++ b/tools/slims.py
@@ -85,11 +85,14 @@ def translate_slims_info(record):
 
     investigator = 'CGG'  # NOTE: Needed?
 
-    department_record = slims_connection.fetch_by_pk('ReferenceDataRecord', record.cntn_cstm_department.value)
-    department = department_record.rdrc_name.value  
-    responder_records = [slims_connection.fetch_by_pk('ReferenceDataRecord', pk) for
-                         pk in department_record.rdrc_cstm_responder.value]
-    responder_emails = [rec.rdrc_cstm_email.value for rec in responder_records]
+    department = None
+    responder_emails = []
+    if record.cntn_cstm_department.value is not None:
+        department_record = slims_connection.fetch_by_pk('ReferenceDataRecord', record.cntn_cstm_department.value)
+        department = department_record.rdrc_name.value  
+        responder_records = [slims_connection.fetch_by_pk('ReferenceDataRecord', pk) for
+                            pk in department_record.rdrc_cstm_responder.value]
+        responder_emails = [rec.rdrc_cstm_email.value for rec in responder_records]
 
     is_research = record.cntn_cstm_research.value
     research_project = record.cntn_cstm_researchProject.value


### PR DESCRIPTION
### The What

Changed so `department` defaults to `None` is nothing is found in Slims.

### The Why

The wrapper would silently crash if it encountered a sample without department info. Also, we do not use the `department` variable, except for adding to the email, and fetching `responder_emails` (unused).

### The How

Change in slims.py

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [ X ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

### Tests

- No longer crashes when encountering samples without department info.
- When wgs-somatic samples are found without department info the log and email are as below: 
```
2025-02-21 16:24:09,933 - INFO - wgs_somatic-run-wrapper - tumor_samples: {'DNA122317': ['tumor', '122317', None, False]}
2025-02-21 16:24:09,933 - INFO - wgs_somatic-run-wrapper - normal_samples: {'DNA122343': ['normal', '122317', None, False]}
```

> Starting wgs_somatic for the following samples in run 250210_A00687_0414_BH3M3TDSXF+6ebe9bfd:
> DNA122317 (T) DNA122343 (N), None
> You will get an email when the results are ready.
> Best regards,
> CGG Cancer

## Verifications
- [ x ] Code reviewed by @Bart-Edelbroek 
- [ x ] Code tested by @Bart-Edelbroek 
