### PR TITLE
Wrapper manual run

### DIFF
--- a/configs/wrapper_config.yaml
+++ b/configs/wrapper_config.yaml
@@ -16,7 +16,9 @@ hg38ref:
   GMS-BT: 'yes'
   GMS-AL: 'yes'
 
-outputdir: '/clinical/data/wgs_somatic/cron'
+cron_outpath: '/clinical/data/wgs_somatic/cron'
+
+manual_outpath: '/clinical/data/wgs_somatic/manual/'
 
 hcp_download_dir: '/clinical/data/wgs_somatic/hcp_downloads'
 

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -105,23 +105,78 @@ def analysis_end(outputdir, tumorsample=None, normalsample=None):
             if normalsample:
                 # these functions are only executed if snakemake workflow has finished successfully
                 yearly_stats(tumorsample, normalsample)
-                copy_results(outputdir)
             else:
                 yearly_stats(tumorsample, 'None')
-                copy_results(outputdir)
         else:
             yearly_stats('None', normalsample)
-            copy_results(outputdir)
+        copy_results(outputdir)
     else:
         pass
 
 
-def wrapper(instrument):
+def submit_pipeline(tumorsample, normalsample, outpath, config, logger, threads):
+    hg38ref = config['hg38ref']['GMS-BT']
+    timestamp = get_timestamp()
+    if tumorsample and normalsample:
+        logger.info(f'Preparing run: Tumor {tumorsample} and Normal {normalsample}')
+        fastq_dict_tumor = find_or_download_fastqs(tumorsample, logger)
+        fastq_dict_normal = find_or_download_fastqs(normalsample, logger)
+        tumorid = list(fastq_dict_tumor.keys())[0]  # E.g. DNA123456_250101_AHJLJHBGXF
+        outputdir = os.path.join(outpath, f"{tumorid}_{timestamp}")
+        os.makedirs(outputdir, exist_ok=False)  # Make sure a new outputdir is created, not overwriting old results
+        tumor_fastq_dir = link_fastqs_to_outputdir(fastq_dict_tumor, outputdir, logger)
+        normal_fastq_dir = link_fastqs_to_outputdir(fastq_dict_normal, outputdir, logger)
+        pipeline_args = {'outputdir': f'{outputdir}',
+                         'normalname': f'{normalsample}',
+                         'normalfastqs': f'{normal_fastq_dir}',
+                         'tumorname': f'{tumorsample}',
+                         'tumorfastqs': f'{tumor_fastq_dir}',
+                         'hg38ref': f'{hg38ref}'}
+
+    elif tumorsample:
+        logger.info(f'Preparing run: Tumor-only {tumorsample}')
+        fastq_dict_tumor = find_or_download_fastqs(tumorsample, logger)
+        outpath = os.path.join(outpath, "tumor_only")
+        os.makedirs(outpath, exist_ok=True)
+        tumorid = list(fastq_dict_tumor.keys())[0]
+        outputdir = os.path.join(outpath, f"{tumorid}_{timestamp}")
+        os.makedirs(outputdir, exist_ok=False)
+        tumor_fastq_dir = link_fastqs_to_outputdir(fastq_dict_tumor, outputdir, logger)
+        pipeline_args = {'outputdir': f'{outputdir}',
+                         'tumorname': f'{tumorsample}',
+                         'tumorfastqs': f'{tumor_fastq_dir}',
+                         'hg38ref': f'{hg38ref}'}
+
+    elif normalsample:
+        logger.info(f'Preparing run: Normal-only {normalsample}')
+        fastq_dict_normal = find_or_download_fastqs(normalsample, logger)
+        outpath = os.path.join(outpath, "normal_only")
+        os.makedirs(outpath, exist_ok=True)
+        normalid = list(fastq_dict_normal.keys())[0]
+        outputdir = os.path.join(outpath, f"{normalid}_{timestamp}")
+        os.makedirs(outputdir, exist_ok=False)
+        normal_fastq_dir = link_fastqs_to_outputdir(fastq_dict_normal, outputdir, logger)
+        pipeline_args = {'outputdir': f'{outputdir}',
+                         'normalname': f'{normalsample}',
+                         'normalfastqs': f'{normal_fastq_dir}',
+                         'hg38ref': f'{hg38ref}'}
+
+    threads.append(threading.Thread(target=call_script, kwargs=pipeline_args))
+    logger.info(f'Starting wgs_somatic with arguments {pipeline_args}')
+    return outputdir
+
+
+def wrapper(instrument=None, tumorsample=None, normalsample=None, outpath=None, copyresults=False):
     '''Wrapper function'''
+
+    ### Setup ###
     config = read_config(WRAPPER_CONFIG_PATH)
 
     wrapper_log_path = config["wrapper_log_path"]
-    logger = setup_logger('wrapper', os.path.join(wrapper_log_path, f'{instrument}_WS_wrapper.log'))
+    if instrument:
+        logger = setup_logger('wrapper', os.path.join(wrapper_log_path, f'{instrument}_WS_wrapper.log'))
+    else:
+        logger = setup_logger('wrapper', os.path.join(wrapper_log_path, 'Manual_WS_wrapper.log'))
 
     # Empty dict, will update later with T/N pair info
     pair_dict_all_pairs = {}
@@ -134,7 +189,35 @@ def wrapper(instrument):
         except Exception as e:
             error_list.append(f"outputdirectory: {hcptmp} does not exist and could not be created")
 
+    # If outputpath is not specified, get from config
+    if not outpath:
+        if instrument:  # Automatic pipeline submission
+            try:
+                outpath = config['cron_outpath']
+            except KeyError:
+                logger.error('Output path for cron job not specified in the configuration.')
+                raise ValueError('Output path for cron job not specified in the configuration.')
+        if tumorsample:  # Manual pipeline submission
+            try:
+                outpath = config['manual_outpath']
+            except KeyError:
+                logger.error('Output path for manual submission not specified in the configuration.')
+                raise ValueError('Output path for manual submission not specified in the configuration.')
 
+    ### Manual pipeline submission ###
+    if tumorsample:
+        threads = []
+        if normalsample:
+            outputdir = submit_pipeline(tumorsample, normalsample, outpath, config, logger, threads)
+        else:
+            outputdir = submit_pipeline(tumorsample, None, config, outpath, logger, threads)
+        threads[0].start()  # For manual runs we only have one thread
+
+        if copyresults and os.path.isfile(f"{outputdir}/reporting/workflow_finished.txt"):
+            copy_results(outputdir)
+        return
+
+    ### Automatic pipeline submission ###
     # Grab all available local run paths
     local_run_paths = look_for_runs(config, instrument)
     # Read all previously analysed runs
@@ -178,64 +261,10 @@ def wrapper(instrument):
 
         # Uses the dictionary of T/N samples to put the correct pairs together and finds the correct input arguments to the pipeline
         threads = []
-        check_ok_outdirs = []
+        outputdirs = []
         end_threads = []
         final_pairs = []
         paired_samples = []
-
-        def submit_pipeline(tumorsample, normalsample):
-            hg38ref = config['hg38ref']['GMS-BT']
-            timestamp = get_timestamp()
-            outputdir = None
-            if tumorsample and normalsample:
-                logger.info(f'Preparing run: Tumor {tumorsample} and Normal {normalsample}')
-                fastq_dict_tumor = find_or_download_fastqs(tumorsample, logger)
-                fastq_dict_normal = find_or_download_fastqs(normalsample, logger)
-                tumorid = list(fastq_dict_tumor.keys())[0]  # E.g. DNA123456_250101_AHJLJHBGXF
-                outputdir = os.path.join(config['outputdir'], f"{tumorid}_{timestamp}")
-                os.makedirs(outputdir, exist_ok=False)  # Make sure a new outputdir is created, not overwriting old results
-                tumor_fastq_dir = link_fastqs_to_outputdir(fastq_dict_tumor, outputdir, logger)
-                normal_fastq_dir = link_fastqs_to_outputdir(fastq_dict_normal, outputdir, logger)
-                pipeline_args = {'outputdir': f'{outputdir}',
-                                 'normalname': f'{normalsample}',
-                                 'normalfastqs': f'{normal_fastq_dir}',
-                                 'tumorname': f'{tumorsample}',
-                                 'tumorfastqs': f'{tumor_fastq_dir}',
-                                 'hg38ref': f'{hg38ref}'}
-
-            elif tumorsample:
-                logger.info(f'Preparing run: Tumor-only {tumorsample}')
-                fastq_dict_tumor = find_or_download_fastqs(tumorsample, logger)
-                outputdir = os.path.join(config['outputdir'], "tumor_only")
-                os.makedirs(outputdir, exist_ok=True)
-                tumorid = list(fastq_dict_tumor.keys())[0]
-                outputdir = os.path.join(outputdir, f"{tumorid}_{timestamp}")
-                os.makedirs(outputdir, exist_ok=False)
-                tumor_fastq_dir = link_fastqs_to_outputdir(fastq_dict_tumor, outputdir, logger)
-                pipeline_args = {'outputdir': f'{outputdir}',
-                                 'tumorname': f'{tumorsample}',
-                                 'tumorfastqs': f'{tumor_fastq_dir}',
-                                 'hg38ref': f'{hg38ref}'}
-
-            elif normalsample:
-                logger.info(f'Preparing run: Normal-only {normalsample}')
-                fastq_dict_normal = find_or_download_fastqs(normalsample, logger)
-                outputdir = os.path.join(config['outputdir'], "normal_only")
-                os.makedirs(outputdir, exist_ok=True)
-                normalid = list(fastq_dict_normal.keys())[0]
-                outputdir = os.path.join(outputdir, f"{normalid}_{timestamp}")
-                os.makedirs(outputdir, exist_ok=False)
-                normal_fastq_dir = link_fastqs_to_outputdir(fastq_dict_normal, outputdir, logger)
-                pipeline_args = {'outputdir': f'{outputdir}',
-                                 'normalname': f'{normalsample}',
-                                 'normalfastqs': f'{normal_fastq_dir}',
-                                 'hg38ref': f'{hg38ref}'}
-
-            threads.append(threading.Thread(target=call_script, kwargs=pipeline_args))
-            logger.info(f'Starting wgs_somatic with arguments {pipeline_args}')
-            check_ok_outdirs.append(outputdir)
-            end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, tumorsample, normalsample)))
-        # End of submit_pipeline function
 
         tumor_samples = {}
         normal_samples = {}
@@ -258,16 +287,23 @@ def wrapper(instrument):
                 if t_ID == n_ID or t_ID == n_key.split("DNA")[1] or n_ID == t_key.split("DNA")[1]:
                     paired_samples.append((t_key, n_key))
                     paired = True
-                    submit_pipeline(t_key, n_key)
+                    outputdir = submit_pipeline(t_key, n_key, outpath, config, logger, threads)
+                    outputdirs.append(outputdir)
+                    end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, tumorsample, normalsample)))
                     final_pairs.append(f'{t_key} (T) {n_key} (N), {n_value[2]} {["prio" if (n_value[3] or t_value[3]) else ""][0]}')
                     break
+
             if not paired:
-                submit_pipeline(t_key, None)
+                outputdir = submit_pipeline(t_key, None, outpath, config, logger, threads)
+                outputdirs.append(outputdir)
+                end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, tumorsample, normalsample)))
                 final_pairs.append(f'{t_key} (T), {t_value[2]} {["prio" if t_value[3] else ""][0]}')
 
         for n_key in normal_samples:
             if not any(n_key == pair[1] for pair in paired_samples):
-                submit_pipeline(None, n_key)
+                outputdir = submit_pipeline(None, n_key, outpath, config, logger, threads)
+                outputdirs.append(outputdir)
+                end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, tumorsample, normalsample)))
                 final_pairs.append(f'{n_key} (N), {n_value[2]} {["prio" if n_value[3] else ""][0]}')
 
         # Start several samples at the same time
@@ -285,30 +321,22 @@ def wrapper(instrument):
         ok_samples = []
         bad_samples = []
         # Check if all samples in run have finished successfully. If not, exit script and send error email.
-        for outdir, sample_info in zip(check_ok_outdirs, final_pairs):
-            if check_ok(outdir) == True:
+        for outputdir, sample_info in zip(outputdirs, final_pairs):
+            if check_ok(outputdir) == True:
                 ok_samples.append(sample_info)
                 logger.info(f'Finished correctly: {sample_info}')
             else:
                 logger.info(f'Not finished correctly: {sample_info}')
                 bad_samples.append(sample_info)
+
         if bad_samples:
             # send emails about which samples ok and which not ok
             error_email(Rctx_run.run_name, ok_samples, bad_samples)
-            if ok_samples:
-                # yearly stats ok samples
-                # even though thread starts for all samples, function checks if sample ok
-                # so it will only do yearly stats for ok samples
-                for t in end_threads:
-                    t.start()
-                for u in end_threads:
-                    u.join()
-            sys.exit()
+        else:
+            logger.info('All jobs have finished successfully')
+            end_email(Rctx_run.run_name, final_pairs)
 
-        logger.info('All jobs have finished successfully')
-        end_email(Rctx_run.run_name, final_pairs)
-
-        # If all jobs have finished successfully - add to yearly stats
+        # Run analysis_end for all samples in run, will check again which (if any) are ok
         for t in end_threads:
             t.start()
         for u in end_threads:
@@ -324,10 +352,15 @@ def wrapper(instrument):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-i', '--instrument', help='For example novaseq_687_gc or novaseq_A01736', required=True)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument('-i', '--instrument', help='For example novaseq_687_gc or novaseq_A01736')
+    group.add_argument('--tumorsample', help='Specify the name of the tumor sample (e.g. DNA123456)')
+    parser.add_argument('--normalsample', help='Specify the name of the normal sample (e.g. DNA123456)', required=False)
+    parser.add_argument('-o', '--outpath', help='Manually specify the path where the outputdir will go', required=False)
+    parser.add_argument('-cr', '--copyresults', help='Copy the results from a manual run to webstore', required=False, action='store_true', default=False)
     args = parser.parse_args()
 
-    wrapper(args.instrument)
+    wrapper(args.instrument, args.tumorsample, args.normalsample, args.outpath, args.copyresults)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
### The What

Allow for manual submission of a tumor (and normal) sample, to download, decompress, and start the pipeline. Can additionally supply outpath and copyresults to decide where the outputdir should be placed, and whether or not to copy the results

### The Why

Makes it very simple and quick to manually submit a wgs-somatic run, especially if the samples are only present on the hcp storage. 

### The How

- Moved the submit_pipeline function to outside of the wrapper function
  - Removed end.threads and copy_results from the submit_pipeline function so that they can be specified for the automated start, but not (necessarily) for the manual run
- Added argparse options for tumor and normal samples 
  - For a manual run, --tumorsample is required
  - `--tumorsample` and `--instrument` are mutually exclusive
- Updated the README

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [X] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

### Tests

- Tried with `python wgs_somatic-run-wrapper.py --normalsample NA24143 --tumorsample NA24385`
  - These samples have 8 fastqs each, all on hcp (ran across different lanes)
  - Caused crashes with the old hcp_download script (too few retries)
  - Rebased with boto3 branch
- Tried with runs where some samples are on seqstore and some are on hcp only

### Other

- We can merge into development if the `hcp-download-boto` branch is already merged into development
- Made the PR into that branch since it otherwise shows the commits of that branch

