### PR TITLE
Add control freec

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -123,6 +123,7 @@ if tumorid:
     include:        "workflows/rules/variantcalling/pindel.smk"
     include:        "workflows/rules/small_tools/tmb_calculation.smk"
     include:        "workflows/rules/small_tools/msi.smk"
+    include:        "workflows/rules/variantcalling/control-freec.smk"
 include:        "workflows/rules/variantcalling/dnascope.smk"
 include:        "workflows/rules/small_tools/ballele.smk"
 include:        "workflows/rules/variantcalling/canvas.smk"

--- a/configs/cluster.yaml
+++ b/configs/cluster.yaml
@@ -96,3 +96,12 @@ index_vcf:
     name: "WGSsomatic_{rule}_{wildcards.file}"
     output: "WGSsomatic_{rule}_{wildcards.file}.stdout"
     error: "WGSsomatic_{rule}_{wildcards.file}.stderr"
+
+control_freec_pileup:
+    threads: 64
+
+control_freec_run:
+    threads: 64
+
+control_freec_plot:
+    threads: 4

--- a/configs/cluster.yaml
+++ b/configs/cluster.yaml
@@ -101,7 +101,7 @@ control_freec_pileup:
     threads: 64
 
 control_freec_run:
-    threads: 64
+    threads: 4
     name: "WGSsomatic_{rule}_ploidy{wildcards.ploidy}_{wildcards.sname}"
     output: "WGSsomatic_{rule}_ploidy{wildcards.ploidy}_{wildcards.sname}.stdout"
     error: "WGSsomatic_{rule}_ploidy{wildcards.ploidy}_{wildcards.sname}.stderr"

--- a/configs/cluster.yaml
+++ b/configs/cluster.yaml
@@ -102,6 +102,12 @@ control_freec_pileup:
 
 control_freec_run:
     threads: 64
+    name: "WGSsomatic_{rule}_ploidy{wildcards.ploidy}_{wildcards.sname}"
+    output: "WGSsomatic_{rule}_ploidy{wildcards.ploidy}_{wildcards.sname}.stdout"
+    error: "WGSsomatic_{rule}_ploidy{wildcards.ploidy}_{wildcards.sname}.stderr"
 
 control_freec_plot:
     threads: 4
+    name: "WGSsomatic_{rule}_ploidy{wildcards.ploidy}_{wildcards.sname}"
+    output: "WGSsomatic_{rule}_ploidy{wildcards.ploidy}_{wildcards.sname}.stdout"
+    error: "WGSsomatic_{rule}_ploidy{wildcards.ploidy}_{wildcards.sname}.stderr"

--- a/configs/config_hg38.json
+++ b/configs/config_hg38.json
@@ -12,6 +12,10 @@
             "kmerfile": "/canvasfiles/canvasfiles/kmer.fa",
             "filter13": "/canvasfiles/canvasfiles/filter13.bed"
         },
+        "control-freec":
+        {
+            "sing": "/medstore/Development/wgs_somatic_freec/singularities/control-freec-11.6/control-freec-11.6.sif"
+        },
         "msi":
         {
             "sing": "/clinical/exec/wgs_somatic/dependencies/singularities/msisensor-pro-1.3.0.sif"
@@ -33,10 +37,6 @@
             "dbsnp": "/ncbi/Homo_sapiens_assembly38.dbsnp138.vcf.gz",
             "dnascope_m": "/sentieon/SentieonDNAscopeModelBeta0.5.model",
             "tnscope_m": "/sentieon/Sentieon_GiAB_201711.model"
-        },
-        "control-freec":
-        {
-            "sing": "/medstore/Development/wgs_somatic_freec/singularities/control-freec-11.6/control-freec-11.6.sif"
         }
     },
     "shadow": "copy-minimal",
@@ -108,6 +108,7 @@
         },
         "control-freec":
         {
+            "ploidy": ["free","2"],
             "chrLenFile": "/clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs.fai",
             "chrFiles": "/clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs/"
         },

--- a/configs/config_hg38.json
+++ b/configs/config_hg38.json
@@ -111,7 +111,8 @@
             "ploidy": ["free","2"],
             "chrLenFile": "/clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs.fai",
             "chrFiles": "/clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs/",
-            "SNPfile": "/clinical/exec/wgs_somatic/dependencies/control_freec/common_dnSNP156_hg38.vcf.gz"
+            "SNPfile": "/clinical/exec/wgs_somatic/dependencies/control_freec/common_dnSNP156_hg38.vcf.gz",
+            "cytoBandIdeo": "/clinical/exec/wgs_somatic/dependencies/control_freec/cytoBandIdeo.txt"
         },
         "share_to_resultdir":
         {

--- a/configs/config_hg38.json
+++ b/configs/config_hg38.json
@@ -110,7 +110,8 @@
         {
             "ploidy": ["free","2"],
             "chrLenFile": "/clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs.fai",
-            "chrFiles": "/clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs/"
+            "chrFiles": "/clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs/",
+            "SNPfile": "/clinical/exec/wgs_somatic/dependencies/control_freec/common_dnSNP156_hg38.vcf.gz"
         },
         "share_to_resultdir":
         {

--- a/configs/config_hg38.json
+++ b/configs/config_hg38.json
@@ -33,6 +33,10 @@
             "dbsnp": "/ncbi/Homo_sapiens_assembly38.dbsnp138.vcf.gz",
             "dnascope_m": "/sentieon/SentieonDNAscopeModelBeta0.5.model",
             "tnscope_m": "/sentieon/Sentieon_GiAB_201711.model"
+        },
+        "control-freec":
+        {
+            "sing": "/medstore/Development/wgs_somatic_freec/singularities/control-freec-11.6/control-freec-11.6.sif"
         }
     },
     "shadow": "copy-minimal",
@@ -101,6 +105,9 @@
         "canvas":
         {
             "annotate_ref": "/clinical/exec/wgs_somatic/dependencies/refseq/hg38/RefseqAll_ncbiRefSeq_hg38_GenesGenepredictions.gtf"            
+        },
+        "control-freec":
+        {
         },
         "share_to_resultdir":
         {

--- a/configs/config_hg38.json
+++ b/configs/config_hg38.json
@@ -108,6 +108,8 @@
         },
         "control-freec":
         {
+            "chrLenFile": "/clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs.fai",
+            "chrFiles": "/clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs/"
         },
         "share_to_resultdir":
         {

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -111,7 +111,7 @@ def copy_results(outputdir, resultdir=None):
 
     # Find resultfiles to copy to resultdir on webstore
     copy_files = []
-    files_match = ['.xlsx', 'CNV_SNV_germline.vcf.gz', 'somatic.vcf.gz', 'refseq3kfilt.vcf.gz']
+    files_match = ['.xlsx', 'CNV_SNV_germline.vcf.gz', 'somatic.vcf.gz', 'refseq3kfilt.vcf.gz', '.png']
     for files in files_match:
         copy_files = copy_files + glob.glob(os.path.join(outputdir, f'*{files}*'))
     copy_files = set(copy_files)

--- a/singularities/control-freec-11.6/control-freec-11.6.def
+++ b/singularities/control-freec-11.6/control-freec-11.6.def
@@ -1,0 +1,18 @@
+Bootstrap: docker
+From: mambaorg/micromamba
+
+%files
+	control-freec-11.6.yaml /control-freec-11.6.yaml
+
+%environment
+    export PATH="${MAMBA_ROOT_PREFIX}/bin:$PATH"
+
+%post -c /bin/bash
+    micromamba install -n base --file control-freec-11.6.yaml && \
+    micromamba clean --all --yes
+
+%runscript
+    #!/bin/bash
+
+    # Activate base environment
+    source /usr/local/bin/_activate_current_env.sh

--- a/singularities/control-freec-11.6/control-freec-11.6.yaml
+++ b/singularities/control-freec-11.6/control-freec-11.6.yaml
@@ -1,0 +1,12 @@
+name: control-freec-11.6
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - control-freec=11.6
+  - bedtools
+  - r-cowplot
+  - r-dplyr
+  - r-ggpubr
+  - sambamba
+  - samtools

--- a/workflows/rules/qc/aggregate_qc.smk
+++ b/workflows/rules/qc/aggregate_qc.smk
@@ -21,12 +21,13 @@ if tumorid:
                 tmb = expand("{stype}/reports/{sname}_tmb.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
                 msi_filtered = expand("{stype}/msi/{sname}_msi_filtered.txt", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 msi = expand("{stype}/msi/{sname}_msi.txt", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+                tumor_info_files = expand("{stype}/control-freec_{ploidy}/{sname}.pileup_info.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid, ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
             output:
                 temp("qc_report/{tumorname}_qc_stats.xlsx")
             run:
                 my_insilicofile = f"{input.insilicofile}".split(" ", 1)[0]
                 insilicodir = os.path.dirname(f"{my_insilicofile}").rsplit("/", 1)[0] # Somehow this stuff works
-                create_excel_main(tumorcov = f"{input.tumorcov}", ycov = f"{input.ycov}" , normalcov = f"{input.normalcov}", tumordedup = f"{input.tumordedup}", normaldedup = f"{input.normaldedup}", tumorvcf = f"{input.tumorvcf}", normalvcf = f"{input.normalvcf}", canvasvcf = f"{input.canvasvcf}", tmb = f"{input.tmb}", msi = f"{input.msi}", msi_red = f"{input.msi_filtered}", output = f"{output}", insilicodir = f"{insilicodir}") 
+                create_excel_main(tumorcov = f"{input.tumorcov}", ycov = f"{input.ycov}" , normalcov = f"{input.normalcov}", tumordedup = f"{input.tumordedup}", normaldedup = f"{input.normaldedup}", tumorvcf = f"{input.tumorvcf}", normalvcf = f"{input.normalvcf}", canvasvcf = f"{input.canvasvcf}", tmb = f"{input.tmb}", msi = f"{input.msi}", msi_red = f"{input.msi_filtered}", tumor_info_files=[f"{file}" for file in input.tumor_info_files], output = f"{output}", insilicodir = f"{insilicodir}") 
     else:
         # excel_qc rule for tumor only
         rule excel_qc:
@@ -36,13 +37,14 @@ if tumorid:
                 tumordedup = expand("{stype}/dedup/{sname}_DEDUP.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
                 tumorvcf = expand("{stype}/dnascope/{sname}_germline_SNVsOnly.recode.vcf", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
                 insilicofile = expand("{stype}/insilico/{insiliconame}/{sname}_{insiliconame}_genes_below10x.xlsx", stype=sampleconfig[tumorname]["stype"], insiliconame=sampleconfig["insilico"], sname=tumorid),
-                tmb = expand("{stype}/reports/{sname}_tmb.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid)
+                tmb = expand("{stype}/reports/{sname}_tmb.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
+                tumor_info_files = expand("{stype}/control-freec_{ploidy}/{sname}.pileup_info.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid, ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
             output:
                 temp("qc_report/{tumorname}_qc_stats.xlsx")
             run:
                 my_insilicofile = f"{input.insilicofile}".split(" ", 1)[0]
                 insilicodir = os.path.dirname(f"{my_insilicofile}").rsplit("/", 1)[0] # Somehow this stuff works
-                create_excel_main(tumorcov = f"{input.tumorcov}", ycov = f"{input.ycov}", tumordedup = f"{input.tumordedup}", tumorvcf = f"{input.tumorvcf}", tmb = f"{input.tmb}", output = f"{output}", insilicodir = f"{insilicodir}")
+                create_excel_main(tumorcov = f"{input.tumorcov}", ycov = f"{input.ycov}", tumordedup = f"{input.tumordedup}", tumorvcf = f"{input.tumorvcf}", tmb = f"{input.tmb}", tumor_info_files=[f"{file}" for file in input.tumor_info_files], output = f"{output}", insilicodir = f"{insilicodir}")
 
 else:
     # excel_qc rule for normal only

--- a/workflows/rules/results_sharing/share_to_resultdir.smk
+++ b/workflows/rules/results_sharing/share_to_resultdir.smk
@@ -38,9 +38,9 @@ if tumorid:
                 #expand("{stype}/manta/{sname}_germline_MantaBNDs.vcf.gzi.csi", sname=normalid, stype=sampleconfig[normalname]["stype"]),
                 expand("{stype}/manta/{sname}_germline_MantaNOBNDs.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=normalid, stype=sampleconfig[normalname]["stype"]),
                 #expand("{stype}/manta/{sname}_germline_MantaNOBNDs.vcf.gz.csi", sname=normalid, stype=sampleconfig[normalname]["stype"])
-                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["control-freec"]["ploidy"]),
-                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["control-freec"]["ploidy"]),
-                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["control-freec"]["ploidy"]),
+                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
             output:
                 "reporting/shared_result_files.txt"
             run:

--- a/workflows/rules/results_sharing/share_to_resultdir.smk
+++ b/workflows/rules/results_sharing/share_to_resultdir.smk
@@ -36,8 +36,11 @@ if tumorid:
                 #expand("{stype}/manta/{sname}_somatic_MantaNOBNDs.vcf.gzi.csi", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/manta/{sname}_germline_MantaBNDs.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=normalid, stype=sampleconfig[normalname]["stype"]),
                 #expand("{stype}/manta/{sname}_germline_MantaBNDs.vcf.gzi.csi", sname=normalid, stype=sampleconfig[normalname]["stype"]),
-                expand("{stype}/manta/{sname}_germline_MantaNOBNDs.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=normalid, stype=sampleconfig[normalname]["stype"])
+                expand("{stype}/manta/{sname}_germline_MantaNOBNDs.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=normalid, stype=sampleconfig[normalname]["stype"]),
                 #expand("{stype}/manta/{sname}_germline_MantaNOBNDs.vcf.gz.csi", sname=normalid, stype=sampleconfig[normalname]["stype"])
+                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["control-freec"]["ploidy"]),
+                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["control-freec"]["ploidy"]),
+                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["control-freec"]["ploidy"]),
             output:
                 "reporting/shared_result_files.txt"
             run:

--- a/workflows/rules/results_sharing/share_to_resultdir.smk
+++ b/workflows/rules/results_sharing/share_to_resultdir.smk
@@ -40,7 +40,7 @@ if tumorid:
                 #expand("{stype}/manta/{sname}_germline_MantaNOBNDs.vcf.gz.csi", sname=normalid, stype=sampleconfig[normalname]["stype"])
                 expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
             output:
                 "reporting/shared_result_files.txt"
             run:

--- a/workflows/rules/results_sharing/share_to_resultdir.smk
+++ b/workflows/rules/results_sharing/share_to_resultdir.smk
@@ -41,6 +41,9 @@ if tumorid:
                 expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_BAF.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
             output:
                 "reporting/shared_result_files.txt"
             run:
@@ -65,8 +68,11 @@ if tumorid:
                 expand("{stype}/reports/{sname}_baf.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/manta/{sname}_somatic_MantaBNDs.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 #expand("{stype}/manta/{sname}_somatic_MantaBNDs.vcf.gz.csi", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-                expand("{stype}/manta/{sname}_somatic_MantaNOBNDs.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=tumorid, stype=sampleconfig[tumorname]["stype"])
+                expand("{stype}/manta/{sname}_somatic_MantaNOBNDs.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 #expand("{stype}/manta/{sname}_somatic_MantaNOBNDs.vcf.gzi.csi", sname=tumorid, stype=sampleconfig[tumorname]["stype"])
+                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
             output:
                 "reporting/shared_result_files.txt"
             run:

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -25,6 +25,7 @@ if normalid:
             edit_config = pipeconfig["rules"]["control-freec"].get("edit_config", f"{ROOT_DIR}/workflows/scripts/control_freec_edit_config.py"),
             chrLenFile = pipeconfig["rules"]["control-freec"]["chrLenFile"],
             chrFiles = pipeconfig["rules"]["control-freec"]["chrFiles"],
+            SNPfile = pipeconfig["rules"]["control-freec"]["SNPfile"],
         singularity:
             pipeconfig["singularities"]["control-freec"]["sing"]
         threads:
@@ -35,15 +36,14 @@ if normalid:
             tumor_BAF = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_BAF.txt"),
         shell:
             """
-            python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_pileup} {input.normal_pileup} {threads} {output.config}
+            python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_pileup} {input.normal_pileup} {params.chrLenFile} {params.chrFiles} {params.SNPfile} {threads} {output.config}
             freec -conf {output.config}
             """
 
-
     rule control_freec_plot:
         input:
-            ratio = expand("{stype}/control-freec_{ploidy}/{sname}.pileup_ratio.txt", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy="free"),
-            BAF = expand("{stype}/control-freec_{ploidy}/{sname}.pileup_BAF.txt", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy="free"),
+            ratio = "{stype}/control-freec_{ploidy}/{sname}.pileup_ratio.txt",
+            BAF = "{stype}/control-freec_{ploidy}/{sname}.pileup_BAF.txt"
         params:
             plot_script = pipeconfig["rules"]["control-freec"].get("plot_script", f"{ROOT_DIR}/workflows/scripts/control_freec_makeGraph3.0.R"),
             fai =  pipeconfig["referencefai"],

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -22,7 +22,9 @@ if normalid:
             normal_pileup = expand("{stype}/realign/{sname}.pileup", sname=normalid, stype=sampleconfig[normalname]["stype"]),
         params:
             config_template = pipeconfig["rules"]["control-freec"].get("config_template", f"{ROOT_DIR}/workflows/scripts/control_freec_config.txt"),
-            edit_config = pipeconfig["rules"]["control-freec"].get("edit_config", f"{ROOT_DIR}/workflows/scripts/control_freec_edit_config.py")
+            edit_config = pipeconfig["rules"]["control-freec"].get("edit_config", f"{ROOT_DIR}/workflows/scripts/control_freec_edit_config.py"),
+            chrLenFile = pipeconfig["rules"]["control-freec"]["chrLenFile"],
+            chrFiles = pipeconfig["rules"]["control-freec"]["chrFiles"],
         singularity:
             pipeconfig["singularities"]["control-freec"]["sing"]
         threads:

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -52,8 +52,8 @@ if normalid:
         output:
             ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png"),
             ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg"),
-            BAF_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.seg"),
+            BAF_igv = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv"),
         shell:
             """
-            Rscript {params.plot_script} {input.ratio} {input.BAF} {params.fai} {output.ratio_plot} {output.ratio_seg} {output.BAF_seg}
+            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {output.ratio_plot} {output.ratio_seg} {output.BAF_igv}
             """

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -39,21 +39,45 @@ if normalid:
             python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_pileup} {input.normal_pileup} {params.chrLenFile} {params.chrFiles} {params.SNPfile} {threads} {output.config}
             freec -conf {output.config}
             """
-
-    rule control_freec_plot:
+else:
+    rule control_freec_run:
         input:
-            ratio = "{stype}/control-freec_{ploidy}/{sname}.pileup_ratio.txt",
-            BAF = "{stype}/control-freec_{ploidy}/{sname}.pileup_BAF.txt"
+            tumor_pileup = expand("{stype}/realign/{sname}.pileup", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
         params:
-            plot_script = pipeconfig["rules"]["control-freec"].get("plot_script", f"{ROOT_DIR}/workflows/scripts/control_freec_makeGraph3.0.R"),
-            fai =  pipeconfig["referencefai"],
+            config_template = pipeconfig["rules"]["control-freec"].get("config_template", f"{ROOT_DIR}/workflows/scripts/control_freec_config.txt"),
+            edit_config = pipeconfig["rules"]["control-freec"].get("edit_config", f"{ROOT_DIR}/workflows/scripts/control_freec_edit_config.py"),
+            chrLenFile = pipeconfig["rules"]["control-freec"]["chrLenFile"],
+            chrFiles = pipeconfig["rules"]["control-freec"]["chrFiles"],
+            SNPfile = pipeconfig["rules"]["control-freec"]["SNPfile"],
+            normal_pileup = "None",
         singularity:
             pipeconfig["singularities"]["control-freec"]["sing"]
+        threads:
+            clusterconf["control_freec_run"]["threads"]
         output:
-            ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png"),
-            ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg"),
-            BAF_igv = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv"),
+            config = temp("{stype}/control-freec_{ploidy}/{sname}.config"),
+            tumor_ratio = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_ratio.txt"),
+            tumor_BAF = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_BAF.txt"),
         shell:
             """
-            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {output.ratio_plot} {output.ratio_seg} {output.BAF_igv}
+            python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_pileup} {params.normal_pileup} {params.chrLenFile} {params.chrFiles} {params.SNPfile} {threads} {output.config}
+            freec -conf {output.config}
             """
+
+rule control_freec_plot:
+    input:
+        ratio = "{stype}/control-freec_{ploidy}/{sname}.pileup_ratio.txt",
+        BAF = "{stype}/control-freec_{ploidy}/{sname}.pileup_BAF.txt"
+    params:
+        plot_script = pipeconfig["rules"]["control-freec"].get("plot_script", f"{ROOT_DIR}/workflows/scripts/control_freec_makeGraph3.0.R"),
+        fai =  pipeconfig["referencefai"],
+    singularity:
+        pipeconfig["singularities"]["control-freec"]["sing"]
+    output:
+        ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png"),
+        ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg"),
+        BAF_igv = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv"),
+    shell:
+        """
+        Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {output.ratio_plot} {output.ratio_seg} {output.BAF_igv}
+        """

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -1,0 +1,57 @@
+rule control_freec_pileup:
+    input:
+        bam = "{stype}/realign/{sname}_REALIGNED.bam"
+    params:
+        ref = pipeconfig["referencegenome"],
+    singularity:
+        pipeconfig["singularities"]["control-freec"]["sing"]
+    threads:
+        clusterconf["control_freec_pileup"]["threads"]
+    output:
+        pileup = temp("{stype}/realign/{sname}.pileup")
+    shell:
+        """
+        mkdir -p {wildcards.stype}/control-freec/
+        sambamba mpileup -t {threads} -o {output.pileup} {input.bam} --samtools -f {params.ref} -d 8000 -Q 0
+        """
+
+if normalid:
+    rule control_freec_run:
+        input:
+            tumor_pileup = expand("{stype}/realign/{sname}.pileup", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+            normal_pileup = expand("{stype}/realign/{sname}.pileup", sname=normalid, stype=sampleconfig[normalname]["stype"]),
+        params:
+            config_template = pipeconfig["rules"]["control-freec"].get("config_template", f"{ROOT_DIR}/workflows/scripts/control_freec_config.txt"),
+            edit_config = pipeconfig["rules"]["control-freec"].get("edit_config", f"{ROOT_DIR}/workflows/scripts/control_freec_edit_config.py")
+        singularity:
+            pipeconfig["singularities"]["control-freec"]["sing"]
+        threads:
+            clusterconf["control_freec_run"]["threads"]
+        output:
+            config = temp("{stype}/control-freec_{ploidy}/{sname}.config"),
+            tumor_ratio = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_ratio.txt"),
+            tumor_BAF = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_BAF.txt"),
+        shell:
+            """
+            python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_pileup} {input.normal_pileup} {threads} {output.config}
+            freec -conf {output.config}
+            """
+
+
+    rule control_freec_plot:
+        input:
+            ratio = expand("{stype}/control-freec_{ploidy}/{sname}.pileup_ratio.txt", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy="free"),
+            BAF = expand("{stype}/control-freec_{ploidy}/{sname}.pileup_BAF.txt", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy="free"),
+        params:
+            plot_script = pipeconfig["rules"]["control-freec"].get("plot_script", f"{ROOT_DIR}/workflows/scripts/control_freec_makeGraph3.0.R"),
+            fai =  pipeconfig["referencefai"],
+        singularity:
+            pipeconfig["singularities"]["control-freec"]["sing"]
+        output:
+            ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ratio.png"),
+            ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ratio.seg"),
+            BAF_seg = temp("{stype}/control-freec_{ploidy}/{sname}_BAF.seg"),
+        shell:
+            """
+            Rscript {params.plot_script} {input.ratio} {input.BAF} {params.fai} {output.ratio_plot} {output.ratio_seg} {output.BAF_seg}
+            """

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -26,6 +26,7 @@ if normalid:
             chrLenFile = pipeconfig["rules"]["control-freec"]["chrLenFile"],
             chrFiles = pipeconfig["rules"]["control-freec"]["chrFiles"],
             SNPfile = pipeconfig["rules"]["control-freec"]["SNPfile"],
+            normalid = normalid,
         singularity:
             pipeconfig["singularities"]["control-freec"]["sing"]
         threads:
@@ -34,11 +35,41 @@ if normalid:
             config = temp("{stype}/control-freec_{ploidy}/{sname}.config"),
             tumor_ratio = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_ratio.txt"),
             tumor_BAF = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_BAF.txt"),
+            normal_ratio = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_normal_ratio.txt"),
+            normal_BAF = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_normal_BAF.txt"),
         shell:
             """
             python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_pileup} {input.normal_pileup} {params.chrLenFile} {params.chrFiles} {params.SNPfile} {threads} {output.config}
             freec -conf {output.config}
+            mv {wildcards.stype}/control-freec_{wildcards.ploidy}/{params.normalid}.pileup_BAF.txt {output.normal_BAF}
             """
+
+    rule control_freec_plot:
+        input:
+            ratio = "{stype}/control-freec_{ploidy}/{sname}.pileup_ratio.txt",
+            BAF = "{stype}/control-freec_{ploidy}/{sname}.pileup_BAF.txt",
+            normal_ratio = "{stype}/control-freec_{ploidy}/{sname}.pileup_normal_ratio.txt",
+            normal_BAF = "{stype}/control-freec_{ploidy}/{sname}.pileup_normal_BAF.txt",
+        params:
+            plot_script = pipeconfig["rules"]["control-freec"].get("plot_script", f"{ROOT_DIR}/workflows/scripts/control_freec_makeGraph3.0.R"),
+            fai =  pipeconfig["referencefai"],
+            cytoBandIdeo = pipeconfig["rules"]["control-freec"]["cytoBandIdeo"],
+        singularity:
+            pipeconfig["singularities"]["control-freec"]["sing"]
+        output:
+            ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png"),
+            ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg"),
+            BAF_igv = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv"),
+            normal_ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.png"),
+            normal_ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.seg"),
+            normal_BAF_igv = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_BAF.igv"),
+        shell:
+            """
+            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {output.ratio_plot} {output.ratio_seg} {output.BAF_igv}
+            Rscript {params.plot_script} {wildcards.sname} {input.normal_ratio} {input.normal_BAF} {params.fai} {output.normal_ratio_plot} {output.normal_ratio_seg} {output.normal_BAF_igv}
+            """
+
+
 else:
     rule control_freec_run:
         input:
@@ -64,20 +95,21 @@ else:
             freec -conf {output.config}
             """
 
-rule control_freec_plot:
-    input:
-        ratio = "{stype}/control-freec_{ploidy}/{sname}.pileup_ratio.txt",
-        BAF = "{stype}/control-freec_{ploidy}/{sname}.pileup_BAF.txt"
-    params:
-        plot_script = pipeconfig["rules"]["control-freec"].get("plot_script", f"{ROOT_DIR}/workflows/scripts/control_freec_makeGraph3.0.R"),
-        fai =  pipeconfig["referencefai"],
-    singularity:
-        pipeconfig["singularities"]["control-freec"]["sing"]
-    output:
-        ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png"),
-        ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg"),
-        BAF_igv = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv"),
-    shell:
-        """
-        Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {output.ratio_plot} {output.ratio_seg} {output.BAF_igv}
-        """
+    rule control_freec_plot:
+        input:
+            ratio = "{stype}/control-freec_{ploidy}/{sname}.pileup_ratio.txt",
+            BAF = "{stype}/control-freec_{ploidy}/{sname}.pileup_BAF.txt",
+        params:
+            plot_script = pipeconfig["rules"]["control-freec"].get("plot_script", f"{ROOT_DIR}/workflows/scripts/control_freec_makeGraph3.0.R"),
+            fai =  pipeconfig["referencefai"],
+            cytoBandIdeo = pipeconfig["rules"]["control-freec"]["cytoBandIdeo"],
+        singularity:
+            pipeconfig["singularities"]["control-freec"]["sing"]
+        output:
+            ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png"),
+            ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg"),
+            BAF_igv = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv"),
+        shell:
+            """
+            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {output.ratio_plot} {output.ratio_seg} {output.BAF_igv}
+            """

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -65,8 +65,8 @@ if normalid:
             normal_BAF_igv = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_BAF.igv"),
         shell:
             """
-            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {output.ratio_plot} {output.ratio_seg} {output.BAF_igv}
-            Rscript {params.plot_script} {wildcards.sname} {input.normal_ratio} {input.normal_BAF} {params.fai} {output.normal_ratio_plot} {output.normal_ratio_seg} {output.normal_BAF_igv}
+            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg} {output.BAF_igv}
+            Rscript {params.plot_script} {wildcards.sname} {input.normal_ratio} {input.normal_BAF} {params.fai} {params.cytoBandIdeo} {output.normal_ratio_plot} {output.normal_ratio_seg} {output.normal_BAF_igv}
             """
 
 
@@ -111,5 +111,5 @@ else:
             BAF_igv = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv"),
         shell:
             """
-            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {output.ratio_plot} {output.ratio_seg} {output.BAF_igv}
+            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg} {output.BAF_igv}
             """

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -50,9 +50,9 @@ if normalid:
         singularity:
             pipeconfig["singularities"]["control-freec"]["sing"]
         output:
-            ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ratio.png"),
-            ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ratio.seg"),
-            BAF_seg = temp("{stype}/control-freec_{ploidy}/{sname}_BAF.seg"),
+            ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png"),
+            ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg"),
+            BAF_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.seg"),
         shell:
             """
             Rscript {params.plot_script} {input.ratio} {input.BAF} {params.fai} {output.ratio_plot} {output.ratio_seg} {output.BAF_seg}

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -37,6 +37,7 @@ if normalid:
             tumor_BAF = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_BAF.txt"),
             normal_ratio = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_normal_ratio.txt"),
             normal_BAF = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_normal_BAF.txt"),
+            info = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_info.txt"),
         shell:
             """
             python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_pileup} {input.normal_pileup} {params.chrLenFile} {params.chrFiles} {params.SNPfile} {threads} {output.config}
@@ -89,6 +90,7 @@ else:
             config = temp("{stype}/control-freec_{ploidy}/{sname}.config"),
             tumor_ratio = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_ratio.txt"),
             tumor_BAF = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_BAF.txt"),
+            info = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_info.txt"),
         shell:
             """
             python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_pileup} {params.normal_pileup} {params.chrLenFile} {params.chrFiles} {params.SNPfile} {threads} {output.config}

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -9,6 +9,8 @@ rule control_freec_pileup:
         clusterconf["control_freec_pileup"]["threads"]
     output:
         pileup = temp("{stype}/realign/{sname}.pileup")
+    shadow:
+        pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
     shell:
         """
         mkdir -p {wildcards.stype}/control-freec/
@@ -38,6 +40,8 @@ if normalid:
             normal_ratio = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_normal_ratio.txt"),
             normal_BAF = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_normal_BAF.txt"),
             info = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_info.txt"),
+        shadow:
+            pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
         shell:
             """
             python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_pileup} {input.normal_pileup} {params.chrLenFile} {params.chrFiles} {params.SNPfile} {threads} {output.config}
@@ -64,6 +68,8 @@ if normalid:
             normal_ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.png"),
             normal_ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.seg"),
             normal_BAF_igv = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_BAF.igv"),
+        shadow:
+            pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
         shell:
             """
             Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg} {output.BAF_igv}
@@ -91,6 +97,8 @@ else:
             tumor_ratio = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_ratio.txt"),
             tumor_BAF = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_BAF.txt"),
             info = temp("{stype}/control-freec_{ploidy}/{sname}.pileup_info.txt"),
+        shadow:
+            pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
         shell:
             """
             python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_pileup} {params.normal_pileup} {params.chrLenFile} {params.chrFiles} {params.SNPfile} {threads} {output.config}
@@ -111,6 +119,8 @@ else:
             ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png"),
             ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg"),
             BAF_igv = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv"),
+        shadow:
+            pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
         shell:
             """
             Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg} {output.BAF_igv}

--- a/workflows/scripts/control_freec_config.txt
+++ b/workflows/scripts/control_freec_config.txt
@@ -1,0 +1,91 @@
+###For more options see: http://boevalab.com/FREEC/tutorial.html#CONFIG ###
+
+
+[general]
+
+##parameters chrLenFile and ploidy are required.
+
+chrLenFile = /medstore/Development/wgs_somatic_freec/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.fai
+ploidy = 1,2,3,4
+#sambamba = /home/xedeba/micromamba/envs/control-freec/bin/sambamba
+contaminationAdjustment = TRUE
+outputDir = ./DNA105848/
+
+##Parameter "breakPointThreshold" specifies the maximal slope of the slope of residual sum of squares. 
+##This should be a positive value. The closer it is to Zero, the more breakpoints will be called. Its recommended value is between 0.01 and 0.08.
+
+breakPointThreshold = .8
+
+
+##Either coefficientOfVariation or window must be specified for whole genome sequencing data. Set window=0 for exome sequencing data.
+
+#coefficientOfVariation = 0.01
+window = 50000
+#step=10000
+
+##Either chrFiles or GCcontentProfile must be specified too if no control dataset is available. 
+##If you provide a path to chromosome files, Control-FREEC will look for the following fasta files in your directory (in this order): 
+##1, 1.fa, 1.fasta, chr1.fa, chr1.fasta; 2, 2.fa, etc.
+## Please ensure that you don't have other files but sequences having the listed names in this directory. 
+chrFiles = /medstore/Development/wgs_somatic_freec/hg38_chrs
+#GCcontentProfile = test/GC_profile_50kb.cnp
+
+
+##if you are working with something non-human, we may need to modify these parameters:
+#minExpectedGC = 0.35
+#maxExpectedGC = 0.55
+
+
+#readCountThreshold=10
+
+#numberOfProcesses = 4
+#contaminationAdjustment = TRUE
+#contamination = 0.4
+#minMappabilityPerWindow = 0.95
+
+
+##If the parameter gemMappabilityFile is not specified, then the fraction of non-N nucleotides per window is used as Mappability.
+
+#gemMappabilityFile = /GEM_mappability/out76.gem
+
+
+#breakPointType = 4
+#forceGCcontentNormalization = 0
+sex = XY
+
+maxThreads = 64
+
+##set BedGraphOutput=TRUE if you want to create a BedGraph track for visualization in the UCSC genome browser:
+BedGraphOutput=TRUE
+
+[sample]
+
+mateFile = DNA105848/DNA105848_241218_DNA105848_REALIGNED.pileup
+#mateCopyNumberFile = test/sample.cpn
+inputFormat = pileup
+mateOrientation = FR
+
+##use "mateOrientation=0" for sorted .SAM and .BAM
+
+[control]
+
+mateFile = DNA105848/DNA104194_241218_DNA104194_REALIGNED.pileup
+#mateCopyNumberFile = path/control.cpn
+inputFormat = pileup
+mateOrientation = FR
+
+[BAF]
+
+##use the following options to calculate B allele frequency profiles and genotype status. This option can only be used if "inputFormat=pileup"
+
+#makePileup = /clinical/exec/wgs_somatic/dependencies/ncbi/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz
+#fastaFile = /clinical/exec/wgs_somatic/dependencies/ncbi/hg38/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna
+SNPfile = /clinical/exec/wgs_somatic/dependencies/ncbi/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz
+#minimalCoveragePerPosition = 5
+#shiftInQuality = 33
+
+[target]
+
+##use a tab-delimited .BED file to specify capture regions (control dataset is needed to use this option):
+
+#captureRegions = /bioinfo/users/vboeva/Desktop/testChr19/capture.bed

--- a/workflows/scripts/control_freec_config.txt
+++ b/workflows/scripts/control_freec_config.txt
@@ -8,7 +8,7 @@ chrLenFile = /clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs.fai
 chrFiles = /clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs/
 ploidy = 1,2,3,4
 outputDir = ./
-maxThreads = 64
+maxThreads = 4
 
 
 ##Parameter "breakPointThreshold" specifies the maximal slope of the slope of residual sum of squares. The closer it is to Zero, the more breakpoints will be called.
@@ -24,7 +24,7 @@ window = 50000
 #readCountThreshold=10
 
 #numberOfProcesses = 4
-#contaminationAdjustment = TRUE
+contaminationAdjustment = TRUE
 #contamination = 0.4
 #minMappabilityPerWindow = 0.95
 

--- a/workflows/scripts/control_freec_config.txt
+++ b/workflows/scripts/control_freec_config.txt
@@ -35,7 +35,7 @@ sex = XY
 
 
 ##set BedGraphOutput=TRUE if you want to create a BedGraph track for visualization in the UCSC genome browser:
-BedGraphOutput=TRUE
+BedGraphOutput=FALSE
 
 [sample]
 
@@ -50,6 +50,8 @@ inputFormat = pileup
 mateOrientation = FR
 
 [BAF]
+
+SNPfile = /clinical/exec/wgs_somatic/dependencies/control_freec/common_dnSNP156_hg38.vcf.gz
 
 [target]
 

--- a/workflows/scripts/control_freec_config.txt
+++ b/workflows/scripts/control_freec_config.txt
@@ -1,40 +1,25 @@
 ###For more options see: http://boevalab.com/FREEC/tutorial.html#CONFIG ###
 
-
 [general]
 
-##parameters chrLenFile and ploidy are required.
+##below parameters are edited by control_freec_edit_config.py
 
-chrLenFile = /medstore/Development/wgs_somatic_freec/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.fai
+chrLenFile = /clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs.fai
+chrFiles = /clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs/
 ploidy = 1,2,3,4
-#sambamba = /home/xedeba/micromamba/envs/control-freec/bin/sambamba
-contaminationAdjustment = TRUE
-outputDir = ./DNA105848/
+outputDir = ./
+maxThreads = 64
 
-##Parameter "breakPointThreshold" specifies the maximal slope of the slope of residual sum of squares. 
-##This should be a positive value. The closer it is to Zero, the more breakpoints will be called. Its recommended value is between 0.01 and 0.08.
+
+##Parameter "breakPointThreshold" specifies the maximal slope of the slope of residual sum of squares. The closer it is to Zero, the more breakpoints will be called.
 
 breakPointThreshold = .8
-
 
 ##Either coefficientOfVariation or window must be specified for whole genome sequencing data. Set window=0 for exome sequencing data.
 
 #coefficientOfVariation = 0.01
 window = 50000
 #step=10000
-
-##Either chrFiles or GCcontentProfile must be specified too if no control dataset is available. 
-##If you provide a path to chromosome files, Control-FREEC will look for the following fasta files in your directory (in this order): 
-##1, 1.fa, 1.fasta, chr1.fa, chr1.fasta; 2, 2.fa, etc.
-## Please ensure that you don't have other files but sequences having the listed names in this directory. 
-chrFiles = /medstore/Development/wgs_somatic_freec/hg38_chrs
-#GCcontentProfile = test/GC_profile_50kb.cnp
-
-
-##if you are working with something non-human, we may need to modify these parameters:
-#minExpectedGC = 0.35
-#maxExpectedGC = 0.55
-
 
 #readCountThreshold=10
 
@@ -44,48 +29,30 @@ chrFiles = /medstore/Development/wgs_somatic_freec/hg38_chrs
 #minMappabilityPerWindow = 0.95
 
 
-##If the parameter gemMappabilityFile is not specified, then the fraction of non-N nucleotides per window is used as Mappability.
-
-#gemMappabilityFile = /GEM_mappability/out76.gem
-
-
 #breakPointType = 4
 #forceGCcontentNormalization = 0
 sex = XY
 
-maxThreads = 64
 
 ##set BedGraphOutput=TRUE if you want to create a BedGraph track for visualization in the UCSC genome browser:
 BedGraphOutput=TRUE
 
 [sample]
 
-mateFile = DNA105848/DNA105848_241218_DNA105848_REALIGNED.pileup
-#mateCopyNumberFile = test/sample.cpn
+mateFile = 
 inputFormat = pileup
 mateOrientation = FR
 
-##use "mateOrientation=0" for sorted .SAM and .BAM
-
 [control]
 
-mateFile = DNA105848/DNA104194_241218_DNA104194_REALIGNED.pileup
-#mateCopyNumberFile = path/control.cpn
+mateFile = 
 inputFormat = pileup
 mateOrientation = FR
 
 [BAF]
 
-##use the following options to calculate B allele frequency profiles and genotype status. This option can only be used if "inputFormat=pileup"
-
-#makePileup = /clinical/exec/wgs_somatic/dependencies/ncbi/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz
-#fastaFile = /clinical/exec/wgs_somatic/dependencies/ncbi/hg38/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna
-SNPfile = /clinical/exec/wgs_somatic/dependencies/ncbi/hg38/Homo_sapiens_assembly38.dbsnp138.vcf.gz
-#minimalCoveragePerPosition = 5
-#shiftInQuality = 33
-
 [target]
 
 ##use a tab-delimited .BED file to specify capture regions (control dataset is needed to use this option):
 
-#captureRegions = /bioinfo/users/vboeva/Desktop/testChr19/capture.bed
+#captureRegions = 

--- a/workflows/scripts/control_freec_edit_config.py
+++ b/workflows/scripts/control_freec_edit_config.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 
-def edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile, chrFiles, threads, output_config):
+def edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile, chrFiles, SNPfile, threads, output_config):
     
     outdir = os.path.dirname(output_config)
     os.makedirs(outdir, exist_ok=True)
@@ -20,6 +20,7 @@ def edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile
     config_data = re.sub(r'^chrLenFile =.*', f'chrLenFile = {chrLenFile}', config_data, flags=re.MULTILINE)
     config_data = re.sub(r'^chrFiles =.*', f'chrFiles = {chrFiles}', config_data, flags=re.MULTILINE)
     config_data = re.sub(r'^maxThreads =.*', f'maxThreads = {threads}', config_data, flags=re.MULTILINE)
+    config_data = re.sub(r'^SNPfile =.*', f'SNPfile = {SNPfile}', config_data, flags=re.MULTILINE)
     with open(output_config, 'w') as file:
         file.write(config_data)
 
@@ -33,7 +34,8 @@ if __name__ == "__main__":
     normal_pileup = sys.argv[4]
     chrLenFile = sys.argv[5]
     chrFiles = sys.argv[6]
-    threads = sys.argv[7]
-    output_config = sys.argv[8]
+    SNPfile = sys.argv[7]
+    threads = sys.argv[8]
+    output_config = sys.argv[9]
 
-    edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile, chrFiles, threads, output_config)
+    edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile, chrFiles, SNPfile, threads, output_config)

--- a/workflows/scripts/control_freec_edit_config.py
+++ b/workflows/scripts/control_freec_edit_config.py
@@ -16,7 +16,10 @@ def edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile
         config_data = re.sub(r'^ploidy =.*', f'ploidy = {ploidy}', config_data, flags=re.MULTILINE)
     config_data = re.sub(r'^outputDir =.*', f'outputDir = {outdir}', config_data, flags=re.MULTILINE)
     config_data = re.sub(r'(\[sample\]\n\nmateFile =).*', f'\\1 {tumor_pileup}', config_data, flags=re.MULTILINE)
-    config_data = re.sub(r'(\[control\]\n\nmateFile =).*', f'\\1 {normal_pileup}', config_data, flags=re.MULTILINE)
+    if normal_pileup.lower() == "none":
+        config_data = re.sub(r'(\[control\]\n\n)mateFile =.*', r'\1#mateFile =', config_data, flags=re.MULTILINE)
+    else:
+        config_data = re.sub(r'(\[control\]\n\nmateFile =).*', f'\\1 {normal_pileup}', config_data, flags=re.MULTILINE)
     config_data = re.sub(r'^chrLenFile =.*', f'chrLenFile = {chrLenFile}', config_data, flags=re.MULTILINE)
     config_data = re.sub(r'^chrFiles =.*', f'chrFiles = {chrFiles}', config_data, flags=re.MULTILINE)
     config_data = re.sub(r'^maxThreads =.*', f'maxThreads = {threads}', config_data, flags=re.MULTILINE)

--- a/workflows/scripts/control_freec_edit_config.py
+++ b/workflows/scripts/control_freec_edit_config.py
@@ -1,0 +1,35 @@
+import re
+import os
+import sys
+
+
+def edit_config(config_template, ploidy, tumor_pileup, normal_pileup, threads, output_config):
+    
+    outdir = os.path.dirname(output_config)
+    os.makedirs(outdir, exist_ok=True)
+
+    with open(config_template, 'r') as file:
+        config_data = file.read()
+    if ploidy == "free":
+        config_data = re.sub(r'^ploidy =.*', 'ploidy = 1,2,3,4,8', config_data, flags=re.MULTILINE)
+    else:
+        config_data = re.sub(r'^ploidy =.*', f'ploidy = {ploidy}', config_data, flags=re.MULTILINE)
+    config_data = re.sub(r'^outputDir =.*', f'outputDir = {outdir}', config_data, flags=re.MULTILINE)
+    config_data = re.sub(r'(\[sample\]\n\nmateFile =).*', f'\\1 {tumor_pileup}', config_data, flags=re.MULTILINE)
+    config_data = re.sub(r'(\[control\]\n\nmateFile =).*', f'\\1 {normal_pileup}', config_data, flags=re.MULTILINE)
+    config_data = re.sub(r'^maxThreads =.*', f'maxThreads = {threads}', config_data, flags=re.MULTILINE)
+    with open(output_config, 'w') as file:
+        file.write(config_data)
+    
+    return output_config
+
+
+if __name__ == "__main__":
+    config_template = sys.argv[1]
+    ploidy = sys.argv[2]
+    tumor_pileup = sys.argv[3]
+    normal_pileup = sys.argv[4]
+    threads = sys.argv[5]
+    output_config = sys.argv[6]
+
+    edit_config(config_template, ploidy, tumor_pileup, normal_pileup, threads, output_config)

--- a/workflows/scripts/control_freec_edit_config.py
+++ b/workflows/scripts/control_freec_edit_config.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 
-def edit_config(config_template, ploidy, tumor_pileup, normal_pileup, threads, output_config):
+def edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile, chrFiles, threads, output_config):
     
     outdir = os.path.dirname(output_config)
     os.makedirs(outdir, exist_ok=True)
@@ -17,10 +17,12 @@ def edit_config(config_template, ploidy, tumor_pileup, normal_pileup, threads, o
     config_data = re.sub(r'^outputDir =.*', f'outputDir = {outdir}', config_data, flags=re.MULTILINE)
     config_data = re.sub(r'(\[sample\]\n\nmateFile =).*', f'\\1 {tumor_pileup}', config_data, flags=re.MULTILINE)
     config_data = re.sub(r'(\[control\]\n\nmateFile =).*', f'\\1 {normal_pileup}', config_data, flags=re.MULTILINE)
+    config_data = re.sub(r'^chrLenFile =.*', f'chrLenFile = {chrLenFile}', config_data, flags=re.MULTILINE)
+    config_data = re.sub(r'^chrFiles =.*', f'chrFiles = {chrFiles}', config_data, flags=re.MULTILINE)
     config_data = re.sub(r'^maxThreads =.*', f'maxThreads = {threads}', config_data, flags=re.MULTILINE)
     with open(output_config, 'w') as file:
         file.write(config_data)
-    
+
     return output_config
 
 
@@ -29,7 +31,9 @@ if __name__ == "__main__":
     ploidy = sys.argv[2]
     tumor_pileup = sys.argv[3]
     normal_pileup = sys.argv[4]
-    threads = sys.argv[5]
-    output_config = sys.argv[6]
+    chrLenFile = sys.argv[5]
+    chrFiles = sys.argv[6]
+    threads = sys.argv[7]
+    output_config = sys.argv[8]
 
-    edit_config(config_template, ploidy, tumor_pileup, normal_pileup, threads, output_config)
+    edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile, chrFiles, threads, output_config)

--- a/workflows/scripts/control_freec_makeGraph3.0.R
+++ b/workflows/scripts/control_freec_makeGraph3.0.R
@@ -109,11 +109,13 @@ dev.off()
 
 writeLines("#track graphType=points maxHeightPixels=300:300:300 color=0,0,220 altColor=220,0,0", con = output_ratio_seg)
 ratio_adjusted %>%
+  mutate(Chromosome = paste0("chr", Chromosome)) %>%
   select(Chromosome, Start, End, corr_ratio) %>%
   write.table(output_ratio_seg, sep = "\t", quote = FALSE, row.names = FALSE, col.names = TRUE, append = TRUE)
 
 
 writeLines('#type=GENE_EXPRESSION\n#track graphtype=points name="DNA116526" color=0,0,255 altColor=255,0,0 maxHeightPixels=80:80:80 viewLimits=-1:1', con = output_BAF_seg)
 BAF_adjusted %>%
+  mutate(Chromosome = paste0("chr", Chromosome)) %>%
   select(Chromosome, Position, Position, BAF) %>%
   write.table(output_BAF_seg, sep = "\t", quote = FALSE, row.names = FALSE, col.names = TRUE, append = TRUE)

--- a/workflows/scripts/control_freec_makeGraph3.0.R
+++ b/workflows/scripts/control_freec_makeGraph3.0.R
@@ -1,8 +1,9 @@
-
+# Load required libraries
 library(ggpubr)
 library(dplyr)
 library(cowplot)
 
+# Function to calculate the most common increment value in a vector
 calculate_increment <- function(vector, num_rows = 5) {
   # Ensure there are enough rows to compare
   if (length(vector) < num_rows) {
@@ -16,42 +17,49 @@ calculate_increment <- function(vector, num_rows = 5) {
   return(as.numeric(names(sort(table(increments), decreasing = TRUE)[1])))
 }
 
-show_points = 5E5
-max_cutoff = 3  # Maximum ratio to plot
+# Constants
+show_points = 5E5  # Number of points to show in the BAF plot
+max_cutoff = 3     # If the ratio is greater than this value * baseline, it will be capped to this value
 
+# Parse command-line arguments
 args <- commandArgs(trailingOnly = TRUE)
-tumor_id <- args[1]
-ratio_file <- args[2]
-BAF_file <- args[3]
-fai_file <- args[4]
-cytoband <- args[5]
-output_ratio_plot <- args[6]
-output_ratio_seg <- args[7]
-output_BAF_igv <- args[8]
+tumor_id <- args[1]               # Tumor sample ID
+ratio_file <- args[2]             # File containing ratio data
+BAF_file <- args[3]               # File containing BAF data
+fai_file <- args[4]               # FAI file (genome index) used to adjust chromosome positions
+cytoband <- args[5]               # Cytoband file (chromosome banding information)
+output_ratio_plot <- args[6]      # Output file for the ratio plot
+output_ratio_seg <- args[7]       # Output file for the ratio segmentation
+output_BAF_igv <- args[8]         # Output file for the BAF IGV track
 
-# Check if the fai file exists
+# Check if the FAI file exists
 if (!file.exists(fai_file)) {
   stop(paste("FAI file not found:", fai_file))
 }
 
+# Set the default theme for plots
 theme_set(theme_pubclean())
 
+# Read the ratio data into a data frame
 ratio <- data.frame(read.table(ratio_file, header=TRUE))
 
+# Read the BAF data into a data frame
 BAF <- data.frame(read.table(BAF_file, header=TRUE))
 
+# Read the FAI file and process it
 fai <- read.table(fai_file, header = FALSE, sep = "\t", 
                   col.names = c("chr", "length", "start", "value1", "value2")) %>%
-  mutate(chr = substr(chr,4,30))%>%
-  mutate(middle = start + (length / 2))
-fai <- fai[1:24,]
+  mutate(chr = substr(chr, 4, 30)) %>%  # Remove the "chr" prefix from chromosome names
+  mutate(middle = start + (length / 2)) # Calculate the middle position of each chromosome
+fai <- fai[1:24,]  # Keep only the first 24 rows (autosomes and sex chromosomes)
 
+# Read the cytoband file and process it
 cytoband <- data.frame(read.table(cytoband, header = TRUE)) %>%
-  mutate(chrom = substr(chrom,4,30)) %>%
-  left_join(fai, by = c("chrom" = "chr")) %>%
-  mutate(adjStart = start + chromStart,
-         adjEnd = start + chromEnd,
-         color = case_when(
+  mutate(chrom = substr(chrom, 4, 30)) %>%  # Remove the "chr" prefix from chromosome names
+  left_join(fai, by = c("chrom" = "chr")) %>%  # Join with FAI data
+  mutate(adjStart = start + chromStart,       # Adjust start positions
+         adjEnd = start + chromEnd,           # Adjust end positions
+         color = case_when(                   # Assign colors based on band type
             gieStain == "acen" ~ "#C00000",
             gieStain == "gneg" ~ "#E0E0E0",
             gieStain == "gpos25" ~ "#C0C0C0",
@@ -63,36 +71,40 @@ cytoband <- data.frame(read.table(cytoband, header = TRUE)) %>%
             TRUE ~ "#FFFFFF"
          ))
 
-ploidy = median(ratio$CopyNumber[which(ratio$MedianRatio>0.8 & ratio$MedianRatio<1.2)], na.rm = T)
-cat (c("INFO: Selected ploidy:", ploidy, "\n"))
+# Calculate the ploidy based on the ratio data
+ploidy = median(ratio$CopyNumber[which(ratio$MedianRatio > 0.8 & ratio$MedianRatio < 1.2)], na.rm = TRUE)
+cat(c("INFO: Selected ploidy:", ploidy, "\n"))
 
+# Calculate the most common increment value in the ratio data
 increment <- calculate_increment(ratio$Start)
 
+# Adjust the ratio data for plotting
 ratio_adjusted <- ratio %>%
   left_join(fai, by = c("Chromosome" = "chr")) %>%
-  mutate(adjStart = Start + start,
-         End = Start + increment,
-         corr_ratio = case_when(
+  mutate(adjStart = Start + start,  # Adjust start positions
+         End = Start + increment,  # Calculate end positions
+         corr_ratio = case_when(   # Correct the ratio values
             Ratio * ploidy > max_cutoff * ploidy ~ Ratio * ploidy - (round(Ratio * ploidy) - max_cutoff * ploidy),
             TRUE ~ Ratio * ploidy),
-         CopyNumber_adj = case_when(
+         CopyNumber_adj = case_when(  # Adjust copy number values
             CopyNumber > max_cutoff * ploidy ~ max_cutoff * ploidy,
             TRUE ~ CopyNumber),
-         color = case_when(
+         color = case_when(  # Assign colors based on ratio values
             Ratio >= 0.9 & Ratio <= 1.1 ~ "around 1",
             Ratio < 0.9 & Ratio >= 0 ~ "below 0.9",
             Ratio > 1.1 ~ "above 1.1",
             TRUE ~ "other"
-         ))%>%
-  filter(Ratio > 0, BAF > 0)
+         )) %>%
+  filter(Ratio > 0, BAF > 0)  # Filter out invalid rows
 
-# Calculate breaks and labels
+# Calculate breaks and labels for the y-axis
 max_corr_ratio <- max(ratio_adjusted$corr_ratio, na.rm = TRUE)
 breaks <- seq(0, max_corr_ratio, by = 1)
 labels <- c(as.character(breaks[-length(breaks)]), paste0(">", max(breaks) - 1))
 
+# Create the ratio plot
 Ratio_plot <- ggplot(fai) +                                              
-  geom_rect(data = cytoband, aes(xmin = adjStart, xmax = adjEnd, ymin = -(max_cutoff*ploidy*0.035), ymax = -(max_cutoff*ploidy*0.01), fill = color)) +
+  geom_rect(data = cytoband, aes(xmin = adjStart, xmax = adjEnd, ymin = -(max_cutoff * ploidy * 0.035), ymax = -(max_cutoff * ploidy * 0.01), fill = color)) +
   geom_point(data = ratio_adjusted, aes(adjStart, corr_ratio, color = color), shape = '.') +
   geom_point(data = ratio_adjusted, aes(adjStart, CopyNumber_adj), shape = '.', col = "#00000050") +
   geom_vline(aes(xintercept = start), col = "grey") +
@@ -104,29 +116,33 @@ Ratio_plot <- ggplot(fai) +
   scale_fill_identity() +
   theme(legend.position = "none", axis.title.x = element_blank(), axis.text.x = element_blank(), axis.ticks.x = element_blank())
 
+# Adjust the BAF data for plotting
 BAF_adjusted <- BAF %>%
   left_join(fai, by = c("Chromosome" = "chr")) %>%
   mutate(adjPosition = Position + start) %>%
   filter(BAF > 0, uncertainty < 1) %>%
   select(Chromosome, Position, adjPosition, BAF, FittedA, FittedB, A, B, uncertainty)
 
-BAF_adjusted_red <- BAF_adjusted%>%
-  slice(which(row_number() %% floor(n()/show_points) == 1))
-BAF_plot <-  ggplot(fai)+                                              
-  geom_vline(aes(xintercept = start), col = "grey")+
-  geom_point(data = BAF_adjusted_red, aes(adjPosition,BAF),shape='.', col = "#00000010")+
-  geom_point(data = BAF_adjusted_red[BAF_adjusted_red$uncertainty > 0 & BAF_adjusted_red$uncertainty < 1,], aes(adjPosition,FittedA),shape=15, size = 0.2, col = "#0090FF")+
-  geom_point(data = BAF_adjusted_red[BAF_adjusted_red$uncertainty > 0 & BAF_adjusted_red$uncertainty < 1,], aes(adjPosition,FittedB),shape=15, size = 0.2, col = "#FF5050")+
+# Reduce the number of points for the BAF plot
+BAF_adjusted_red <- BAF_adjusted %>%
+  slice(which(row_number() %% floor(n() / show_points) == 1))
+
+# Create the BAF plot
+BAF_plot <- ggplot(fai) +                                              
+  geom_vline(aes(xintercept = start), col = "grey") +
+  geom_point(data = BAF_adjusted_red, aes(adjPosition, BAF), shape = '.', col = "#00000010") +
+  geom_point(data = BAF_adjusted_red[BAF_adjusted_red$uncertainty > 0 & BAF_adjusted_red$uncertainty < 1,], aes(adjPosition, FittedA), shape = 15, size = 0.2, col = "#0090FF") +
+  geom_point(data = BAF_adjusted_red[BAF_adjusted_red$uncertainty > 0 & BAF_adjusted_red$uncertainty < 1,], aes(adjPosition, FittedB), shape = 15, size = 0.2, col = "#FF5050") +
   geom_text(aes(label = chr, x = middle, y = Inf), vjust = 1, size = 3) +
-  scale_y_continuous("BAF", limits = c(0, 1), expand = expansion(mult = 0.1))+
-  theme(axis.title.x=element_blank(), axis.text.x = element_blank(), axis.ticks.x = element_blank())
+  scale_y_continuous("BAF", limits = c(0, 1), expand = expansion(mult = 0.1)) +
+  theme(axis.title.x = element_blank(), axis.text.x = element_blank(), axis.ticks.x = element_blank())
 
-
+# Save the combined ratio and BAF plots as a PNG file
 png(output_ratio_plot, width = 24, height = 12, units = "cm", pointsize = 20, res = 1200)
 plot_grid(Ratio_plot, BAF_plot, ncol = 1, align = "v", rel_heights = c(5, 2))
 dev.off()
 
-
+# Write the ratio segmentation data to a file
 writeLines("#track graphType=points maxHeightPixels=300:300:300 color=0,0,0 altColor=0,0,0", con = output_ratio_seg)
 ratio_adjusted %>%
   mutate(Sample = tumor_id,
@@ -134,7 +150,7 @@ ratio_adjusted %>%
   select(Sample, Chromosome, Start, End, corr_ratio) %>%
   write.table(output_ratio_seg, sep = "\t", quote = FALSE, row.names = FALSE, col.names = TRUE, append = TRUE)
 
-
+# Write the BAF data to an IGV-compatible file
 writeLines(paste0(
   '#type=GENE_EXPRESSION\n#track graphtype=points name="',
   tumor_id,

--- a/workflows/scripts/control_freec_makeGraph3.0.R
+++ b/workflows/scripts/control_freec_makeGraph3.0.R
@@ -1,0 +1,119 @@
+
+library(ggpubr)
+library(dplyr)
+library(cowplot)
+
+calculate_increment <- function(vector, num_rows = 5) {
+  # Ensure there are enough rows to compare
+  if (length(vector) < num_rows) {
+    stop("Not enough values to compare.")
+  }
+  
+  # Calculate the differences between the Start values of the first few rows
+  increments <- diff(vector[1:num_rows])
+  
+  # Return the most common increment value
+  return(as.numeric(names(sort(table(increments), decreasing = TRUE)[1])))
+}
+
+show_points = 5E5
+max_cutoff = 3  # Maximum ratio to plot
+
+args <- commandArgs(trailingOnly = TRUE)
+ratio_file <- args[1]
+BAF_file <- args[2]
+fai_file <- args[3]
+output_ratio_plot <- args[4]
+output_ratio_seg <- args[5]
+output_BAF_seg <- args[6]
+
+# Check if the fai file exists
+if (!file.exists(fai_file)) {
+  stop(paste("FAI file not found:", fai_file))
+}
+
+theme_set(theme_pubclean())
+
+ratio <- data.frame(read.table(ratio_file, header=TRUE))
+
+BAF <- data.frame(read.table(BAF_file, header=TRUE))
+
+fai <- read.table(fai_file, header = FALSE, sep = "\t", 
+                  col.names = c("chr", "length", "start", "value1", "value2")) %>%
+  mutate(chr = substr(chr,4,30))%>%
+  mutate(middle = start + (length / 2))
+fai <- fai[1:24,]
+
+ploidy = median(ratio$CopyNumber[which(ratio$MedianRatio>0.8 & ratio$MedianRatio<1.2)], na.rm = T)
+cat (c("INFO: Selected ploidy:", ploidy, "\n"))
+
+increment <- calculate_increment(ratio$Start)
+
+ratio_adjusted <- ratio %>%
+  left_join(fai, by = c("Chromosome" = "chr")) %>%
+  mutate(Start = Start + start,
+         End = Start + increment,
+         corr_ratio = case_when(
+            Ratio * ploidy > max_cutoff * ploidy ~ Ratio * ploidy - (round(Ratio * ploidy) - max_cutoff * ploidy),
+            TRUE ~ Ratio * ploidy),
+         CopyNumber_adj = case_when(
+            CopyNumber > max_cutoff * ploidy ~ max_cutoff * ploidy,
+            TRUE ~ CopyNumber),
+         color = case_when(
+            Ratio >= 0.9 & Ratio <= 1.1 ~ "around 1",
+            Ratio < 0.9 & Ratio >= 0 ~ "below 0.9",
+            Ratio > 1.1 ~ "above 1.1",
+            TRUE ~ "other"
+         ))%>%
+         filter(Ratio > 0, BAF > 0)
+
+# Calculate breaks and labels
+max_corr_ratio <- max(ratio_adjusted$corr_ratio, na.rm = TRUE)
+breaks <- seq(0, max_corr_ratio, by = 1)
+labels <- c(as.character(breaks[-length(breaks)]), paste0(">", max(breaks) - 1))
+
+Ratio_plot <- ggplot(fai) +                                              
+  geom_vline(aes(xintercept = start), col = "grey") +
+  geom_point(data = ratio_adjusted, aes(Start, corr_ratio, color = color), shape = '.') +
+  geom_point(data = ratio_adjusted, aes(Start, CopyNumber_adj), shape = '.', col = "#00000050") +
+  geom_text(aes(label = chr, x = middle, y = Inf), vjust = 1, size = 3) +
+  scale_y_continuous("Copy number",
+                     breaks = breaks,
+                     labels = labels,
+                     expand = expansion(mult = 0.1)) +
+  theme(legend.position = "none", axis.title.x = element_blank())
+
+
+BAF_adjusted <- BAF %>%
+  left_join(fai, by = c("Chromosome" = "chr")) %>%
+  mutate(Position = Position + start) %>%
+  select(Chromosome, Position, BAF, FittedA, FittedB, A, B, uncertainty)
+
+
+BAF_adjusted_red <- BAF_adjusted%>%
+  slice(which(row_number() %% floor(n()/show_points) == 1))
+BAF_plot <-  ggplot(fai)+                                              
+  geom_vline(aes(xintercept = start), col = "grey")+
+  geom_point(data = BAF_adjusted_red, aes(Position,BAF),shape='.', col = "#00000010")+
+  geom_point(data = BAF_adjusted_red[BAF_adjusted_red$uncertainty > 0 & BAF_adjusted_red$uncertainty < 1,], aes(Position,FittedA),shape=15, size = 0.2, col = "#0090FF")+
+  geom_point(data = BAF_adjusted_red[BAF_adjusted_red$uncertainty > 0 & BAF_adjusted_red$uncertainty < 1,], aes(Position,FittedB),shape=15, size = 0.2, col = "#FF5050")+
+  geom_text(aes(label = chr, x = middle, y = Inf), vjust = 1, size = 3) +
+  scale_y_continuous("B-allele frequency", limits = c(0, 1), expand = expansion(mult = 0.1))+
+  theme(axis.title.x=element_blank())
+
+
+png(output_ratio_plot, width = 24, height = 12, units = "cm", pointsize = 20, res = 1200)
+plot_grid(Ratio_plot, BAF_plot, ncol = 1, align = "v", rel_heights = c(2, 1))
+dev.off()
+
+
+writeLines("#track graphType=points maxHeightPixels=300:300:300 color=0,0,220 altColor=220,0,0", con = output_ratio_seg)
+ratio_adjusted %>%
+  select(Chromosome, Start, End, corr_ratio) %>%
+  write.table(output_ratio_seg, sep = "\t", quote = FALSE, row.names = FALSE, col.names = TRUE, append = TRUE)
+
+
+writeLines('#type=GENE_EXPRESSION\n#track graphtype=points name="DNA116526" color=0,0,255 altColor=255,0,0 maxHeightPixels=80:80:80 viewLimits=-1:1', con = output_BAF_seg)
+BAF_adjusted %>%
+  select(Chromosome, Position, Position, BAF) %>%
+  write.table(output_BAF_seg, sep = "\t", quote = FALSE, row.names = FALSE, col.names = TRUE, append = TRUE)

--- a/workflows/scripts/create_qc_excel.py
+++ b/workflows/scripts/create_qc_excel.py
@@ -15,7 +15,6 @@ import glob
 def add_insilico_stats(insilicofolder, main_excel):
     from workflows.scripts.insilico_coverage import insilico_overall_coverage
 
-
     # generate overall insilico coverage dataframe & append to main excel
     ocov_file_list = glob.glob(f"{insilicofolder}/**/*_cov.tsv")
     for ocov in ocov_file_list:
@@ -88,6 +87,7 @@ def get_canvas_tumorinfo(canvasvcf):
                     canvasdict[canvasfield] = canvasfield_value
     return canvasdict
 
+
 def read_tmb_file(filepath):
     tmb_dict = {}
     try:
@@ -136,7 +136,7 @@ def get_msi_info(msi, msi_red):
                         msi_dict[f"msi_filtered_{header}"] = int(value)
                 except ValueError:
                     msi_dict[f"msi_filtered_{header}"] = value
-            
+
     except FileNotFoundError:
         print(f"No file found at {msi} or {msi_red}")
     except Exception as e:
@@ -194,7 +194,7 @@ def create_excel(statsdict, output, normalname='', tumorname='', match_dict={}, 
 
     # Version numbers & tag
     worksheet.merge_range('A3:C3', f"{get_git_reponame()} tag: {get_git_tag()}, commit: {get_git_commit()}")
-    
+
     print(f"STATSDICT: {statsdict}")
 
     # Input calculated sex
@@ -264,7 +264,7 @@ def create_excel(statsdict, output, normalname='', tumorname='', match_dict={}, 
                     worksheet.write(statrow, column_num, match_dict[stat], cellformat[style])
                 else:
                     worksheet.write(statrow, column_num, match_dict[stat])
-                
+
                 column_num += 1
     row += 4
     worksheet.write(row, 0, "CANVAS-STATS", cellformat["section"])
@@ -295,7 +295,7 @@ def create_excel(statsdict, output, normalname='', tumorname='', match_dict={}, 
             worksheet.write(row, 0, key, cellformat["header"])
             worksheet.write(row, 1, msi_dict[key])
             row += 1
-    
+
     row += 2
     worksheet.write(row, 0, "FREEC-PURITIES", cellformat["section"])
     worksheet.write(row, 1, tumorname, cellformat["tumorname"])

--- a/workflows/scripts/create_qc_excel.py
+++ b/workflows/scripts/create_qc_excel.py
@@ -144,7 +144,35 @@ def get_msi_info(msi, msi_red):
     return msi_dict
 
 
-def create_excel(statsdict, output, normalname, tumorname, match_dict, canvasdict, sex, tmb_dict, msi_dict):
+def read_sample_purities(info_files):
+    """
+    Reads Sample_Purity values from multiple pileup_info.txt files.
+    """
+    purities = {}
+    for info_file in info_files:
+        try:
+            with open(info_file, 'r') as file:
+                ploidy = None
+                purity = None
+                for line in file:
+                    line = line.strip()
+                    if line.startswith("Output_Ploidy"):
+                        ploidy = int(line.split("\t")[1])
+                    elif line.startswith("Sample_Purity"):
+                        purity = float(line.split("\t")[1])
+                    # Add to dictionary when both ploidy and purity are found
+                    if ploidy is not None and purity is not None:
+                        purities[ploidy] = purity
+                        ploidy = None  # Reset for the next entry
+                        purity = None
+        except FileNotFoundError:
+            print(f"No file found at {info_file}")
+        except Exception as e:
+            print(f"An error occurred while reading {info_file}: {e}")
+    return purities
+
+
+def create_excel(statsdict, output, normalname='', tumorname='', match_dict={}, canvasdict={}, sex='', tmb_dict={}, msi_dict={}, freec_purities={}):
     current_date = time.strftime("%Y-%m-%d")
     excelfile = xlsxwriter.Workbook(output)
     worksheet = excelfile.add_worksheet("qc_stats")
@@ -267,11 +295,21 @@ def create_excel(statsdict, output, normalname, tumorname, match_dict, canvasdic
             worksheet.write(row, 0, key, cellformat["header"])
             worksheet.write(row, 1, msi_dict[key])
             row += 1
+    
+    row += 2
+    worksheet.write(row, 0, "FREEC-PURITIES", cellformat["section"])
+    worksheet.write(row, 1, tumorname, cellformat["tumorname"])
+    row += 1
+    if freec_purities:
+        for ploidy, purity in freec_purities.items():
+            worksheet.write(row, 0, f"Ploidy {ploidy}", cellformat["header"])
+            worksheet.write(row, 1, purity)
+            row += 1
 
     excelfile.close()
 
 
-def create_excel_main(tumorcov='', ycov='', normalcov='', tumordedup='', normaldedup='', tumorvcf='', normalvcf='', canvasvcf='', tmb='', msi='', msi_red='', output='', insilicodir=''):
+def create_excel_main(tumorcov='', ycov='', normalcov='', tumordedup='', normaldedup='', tumorvcf='', normalvcf='', canvasvcf='', tmb='', msi='', msi_red='', tumor_info_files=[], output='', insilicodir=''):
     print(f"insilicodir: {insilicodir}")
     statsdict = {}
     if tumorcov:
@@ -280,6 +318,7 @@ def create_excel_main(tumorcov='', ycov='', normalcov='', tumordedup='', normald
         statsdict = extract_stats(tumorcov, "coverage",  "tumor", statsdict)
         statsdict = extract_stats(tumordedup, "dedup",  "tumor", statsdict)
         tmb_dict = read_tmb_file(tmb)
+        freec_purities = read_sample_purities(tumor_info_files)
     if normalcov:
         normalcovfile = os.path.basename(normalcov)
         normalname = normalcovfile.replace("_WGScov.tsv", "")
@@ -298,17 +337,17 @@ def create_excel_main(tumorcov='', ycov='', normalcov='', tumordedup='', normald
         if normalcov:
             # Tumour + Normal
             calculated_sex = calc_sex(normalcov, ycov)
-            create_excel(statsdict, output, normalname, tumorname, match_dict, canvas_dict, sex=calculated_sex, tmb_dict=tmb_dict, msi_dict=msi_dict)
+            create_excel(statsdict, output, normalname, tumorname, match_dict, canvas_dict, sex=calculated_sex, tmb_dict=tmb_dict, msi_dict=msi_dict, freec_purities=freec_purities)
             add_insilico_stats(insilicodir, output)
         else:
             # Tumour only
             calculated_sex = calc_sex(tumorcov, ycov)
-            create_excel(statsdict, output, normalname='', tumorname=tumorname, match_dict='', canvasdict='', sex=calculated_sex, tmb_dict=tmb_dict, msi_dict=msi_dict)
+            create_excel(statsdict, output, tumorname=tumorname, sex=calculated_sex, tmb_dict=tmb_dict, freec_purities=freec_purities)
             add_insilico_stats(insilicodir, output) # Maybe this can be commented out if not needed for tumour only
     else:
         # Normal only
         calculated_sex = calc_sex(normalcov, ycov)
-        create_excel(statsdict, output, normalname, tumorname='', match_dict='', canvasdict='', sex=calculated_sex, tmb_dict='', msi_dict=msi_dict)
+        create_excel(statsdict, output, normalname, sex=calculated_sex)
         add_insilico_stats(insilicodir, output)
 
 
@@ -326,6 +365,11 @@ if __name__ == '__main__':
     parser.add_argument('--tmb', nargs='?', help='TMB file', required=False)
     parser.add_argument('--msi', nargs='?', help='MSI result file', required=False)
     parser.add_argument('--msi_red', nargs='?', help='MSI filtered to bed file result file', required=False)
+    parser.add_argument('--tumor_info_files', nargs='*', help='List of tumor pileup_info.txt files for different ploidies', required=False)
     parser.add_argument('-o', '--output', nargs='?', help='fullpath to file to be created (xlsx will be appended if not written)', required=True)
     args = parser.parse_args()
-    create_excel_main(args.tumorcov, args.ycov, args.normalcov, args.tumordedup, args.normaldedup, args.tumorvcf, args.normalvcf, args.canvasvcf, args.tmb, args.msi, args.msi_red, args.output, args.insilicodir)
+    create_excel_main(
+        args.tumorcov, args.ycov, args.normalcov, args.tumordedup, args.normaldedup,
+        args.tumorvcf, args.normalvcf, args.canvasvcf, args.tmb, args.msi, args.msi_red,
+        args.tumor_info_files, args.output, args.insilicodir
+    )

--- a/workflows/tn_workflow.smk
+++ b/workflows/tn_workflow.smk
@@ -64,9 +64,9 @@ rule tn_workflow:
         expand("{stype}/realign/{sname}_REALIGNED.{fmt}", fmt=["cram", "cram.crai"], sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
         expand("{stype}/realign/{sname}_REALIGNED.{fmt}", fmt=["cram", "cram.crai"], sname=normalid, stype=sampleconfig[normalname]["stype"]),
         expand("{stype}/pindel/{sname}_pindel.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-        expand("{stype}/control-freec_{ploidy}/{sname}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy="free"),
-        expand("{stype}/control-freec_{ploidy}/{sname}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy="free"),
-        expand("{stype}/control-freec_{ploidy}/{sname}_BAF.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy="free"),
+        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["control-freec"]["ploidy"]),
+        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["control-freec"]["ploidy"]),
+        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["control-freec"]["ploidy"]),
         "reporting/shared_result_files.txt",
         insilico_files = get_insilico
     output:

--- a/workflows/tn_workflow.smk
+++ b/workflows/tn_workflow.smk
@@ -64,6 +64,9 @@ rule tn_workflow:
         expand("{stype}/realign/{sname}_REALIGNED.{fmt}", fmt=["cram", "cram.crai"], sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
         expand("{stype}/realign/{sname}_REALIGNED.{fmt}", fmt=["cram", "cram.crai"], sname=normalid, stype=sampleconfig[normalname]["stype"]),
         expand("{stype}/pindel/{sname}_pindel.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+        expand("{stype}/control-freec_{ploidy}/{sname}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy="free"),
+        expand("{stype}/control-freec_{ploidy}/{sname}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy="free"),
+        expand("{stype}/control-freec_{ploidy}/{sname}_BAF.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy="free"),
         "reporting/shared_result_files.txt",
         insilico_files = get_insilico
     output:

--- a/workflows/tn_workflow.smk
+++ b/workflows/tn_workflow.smk
@@ -64,9 +64,9 @@ rule tn_workflow:
         expand("{stype}/realign/{sname}_REALIGNED.{fmt}", fmt=["cram", "cram.crai"], sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
         expand("{stype}/realign/{sname}_REALIGNED.{fmt}", fmt=["cram", "cram.crai"], sname=normalid, stype=sampleconfig[normalname]["stype"]),
         expand("{stype}/pindel/{sname}_pindel.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["control-freec"]["ploidy"]),
-        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["control-freec"]["ploidy"]),
-        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["control-freec"]["ploidy"]),
+        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
         "reporting/shared_result_files.txt",
         insilico_files = get_insilico
     output:

--- a/workflows/tn_workflow.smk
+++ b/workflows/tn_workflow.smk
@@ -66,7 +66,7 @@ rule tn_workflow:
         expand("{stype}/pindel/{sname}_pindel.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
         expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
         expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
         "reporting/shared_result_files.txt",
         insilico_files = get_insilico
     output:

--- a/workflows/tumoronly_workflow.smk
+++ b/workflows/tumoronly_workflow.smk
@@ -54,6 +54,9 @@ rule tumoronly_workflow:
         expand("{stype}/reports/{sname}_REALIGNED.bam.tdf", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
         expand("{stype}/realign/{sname}_REALIGNED.{fmt}", fmt=["cram", "cram.crai"], sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
         expand("{stype}/pindel/{sname}_pindel.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
         "reporting/shared_result_files.txt",
         insilico_files = get_insilico
     output:


### PR DESCRIPTION
### The What

Add control-freec to wgs-somatic:
- Run it with ploidy 2 and let it decide ploidy itself
- Output plots with CNV and BAF for both runs
- Output CNV.seg and BAF.igv files for visualization with IGV (similar to what the current Canvas output generates)
- For tumor-normal runs, also output the normal .seg and .igv files

### The Why

We would like to find a replacement for Canvas. Control-freec performed well when it came to predicting purity compared to the histopathology results. For now we will run both tools in parallel so the outputs can be compared.

### The How

- Make container with control-freec tools
- Rule for generating .pileup files
- Rule for running control-freec with ploidy wildcard
  - Generate a config.txt file for the control-freec run 
    - Code for editing the config: workflows/scripts/control_freec_edit_config.py
    - Template config: workflows/scripts/control_freec_config.txt
  - Perform the run
- Rule for plotting control-freec output
  - Code for plotting is broadly based on https://github.com/BoevaLab/FREEC/blob/master/scripts/makeGraph2.0.R
- Add purity and ploidy output from run to excel

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [X] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Tests

Tested tumor-only and tumor-normal runs

