### PR TITLE
Fix pileup tmp

### DIFF
--- a/configs/config_hg38.json
+++ b/configs/config_hg38.json
@@ -112,7 +112,8 @@
             "chrLenFile": "/clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs.fai",
             "chrFiles": "/clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs/",
             "SNPfile": "/clinical/exec/wgs_somatic/dependencies/control_freec/common_dnSNP156_hg38.vcf.gz",
-            "cytoBandIdeo": "/clinical/exec/wgs_somatic/dependencies/control_freec/cytoBandIdeo.txt"
+            "cytoBandIdeo": "/clinical/exec/wgs_somatic/dependencies/control_freec/cytoBandIdeo.txt",
+            "shadow": "minimal"
         },
         "share_to_resultdir":
         {

--- a/tools/custom_email.py
+++ b/tools/custom_email.py
@@ -54,13 +54,13 @@ CGG Cancer
 def error_email(run_name, ok_samples, bad_samples):
     """Send an email about which samples have failed and which samples have succeeded"""
 
-    subject = f'WGS Somatic end mail {run_name}'
+    subject = f'Crashed WGS Somatic {run_name}'
 
-    body = f"""WGS somatic has finished successfully for the following samples in run {run_name}:\n
-{new_line.join(ok_samples)}\n
-The following samples have not finished correctly:\n
+    body = f"""WGS somatic failed for the following samples in run {run_name}:\n
 {new_line.join(bad_samples)}\n
-Errors concerning these samples will be investigated.\n
+The following samples did finish correctly:\n
+{new_line.join(ok_samples)}\n
+Errors concerning the above samples will be investigated.\n
 Best regards,
 CGG Cancer
 """


### PR DESCRIPTION
### No longer copy pileup to /tmp/shadow

We ran out of space on the /tmp drive when copying the large .pileup files. Changing how the shadow rule functions for control-freec should resolve that issue

### Clarify error emails

It has been unclear when wgs-somatic has been failed. Changed the email subject and reordered the email to show the failed samples first. Feel free to change the wording or so.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions
