### PR TITLE
Fix: Allow download from hcp or sg1

### DIFF
--- a/configs/wrapper_config.yaml
+++ b/configs/wrapper_config.yaml
@@ -24,10 +24,18 @@ hcp_download_dir: '/clinical/data/wgs_somatic/hcp_downloads'
 
 hcp:
   download_script: 'tools/hcp_download.py'
+  download_locations:
+    sg1_illumina:
+      bucket: 'illumina'
+      credentials_file: '/clinical/exec/wgs_somatic/dependencies/credentials/sg1.json'
+    sg1_data:
+      bucket: 'data'
+      credentials_file: '/clinical/exec/wgs_somatic/dependencies/credentials/sg1.json'
+    hcp_data:
+      bucket: 'data'
+      credentials_file: '/clinical/exec/wgs_somatic/dependencies/credentials/gmc-legacy_credentials.json'
   queue: 'routine.q'
   threads: 20
-  credentials_file: '/clinical/exec/wgs_somatic/dependencies/credentials/gmc-legacy_credentials.json'
-  bucket: 'data'  # bucket to default to if not found in slims
   peta_script: 'tools/run_petasuite.sh'
   spring_script: 'tools/run_spring.sh' 
   connect_timeout: 10  # Optional arguments for hcp_download.py

--- a/tools/slims.py
+++ b/tools/slims.py
@@ -153,7 +153,7 @@ def download_hcp_fq(remote_key, logger, hcp_runtag):
         try:
             bucket = location_details["bucket"]  # Bucket is specified in the config
 
-            logger.info(f"Trying to download from {location_name})")
+            logger.info(f"Trying to download from {location_name}")
 
             # Construct the download command
             qrsh = [

--- a/tools/slims.py
+++ b/tools/slims.py
@@ -132,7 +132,7 @@ def get_sample_slims_info(Sctx, run_tag):
     return translate_slims_info(SSample.dna)
 
 
-def download_hcp_fq(bucket, remote_key, logger, hcp_runtag):
+def download_hcp_fq(remote_key, logger, hcp_runtag):
     """Find and download fqs from HCP to fastqdir on seqstore for run"""
     config = read_config(WRAPPER_CONFIG_PATH)
 
@@ -279,8 +279,8 @@ def link_fastqs_to_outputdir(fastq_dict, outputdir, logger):
     return fastq_dir
 
 
-def download_and_decompress(bucket, remote_key, logger, hcp_runtag):
-    downloaded_fq = download_hcp_fq(bucket, remote_key, logger, hcp_runtag)
+def download_and_decompress(remote_key, logger, hcp_runtag):
+    downloaded_fq = download_hcp_fq(remote_key, logger, hcp_runtag)
     decompressed_fq = decompress_downloaded_fastq(downloaded_fq, logger)
     return decompressed_fq
 
@@ -317,14 +317,13 @@ def find_or_download_fastqs(sample_name, logger):
                     else:
                         logger.info(f'Fastq {fq_path} does not exist. Need to download from HCP')
                         json_backup = json.loads(fqSSample.fastq.cntn_cstm_demuxerBackupSampleResult.value)
-                        bucket = json_backup['bucket']
                         remote_keys = json_backup['remote_keys']
                         fq_basename_fasterq = os.path.basename(fq_path).replace('.fastq.gz', '.fasterq')
                         fq_basename_spring = os.path.basename(fq_path).replace('.fastq.gz', '.spring')
                         matching_key = [key for key in remote_keys if fq_basename_fasterq in key or fq_basename_spring in key]
                         if matching_key:
                             fq_matched = True
-                            future = executor.submit(download_and_decompress, bucket, matching_key[0], logger, tag)
+                            future = executor.submit(download_and_decompress, matching_key[0], logger, tag)
                             future_to_fq[future] = f'{sample_name}_{tag}'
                         else:
                             logger.info(f'No matching remote keys found for {fq_basename_fasterq} or {fq_basename_spring}')
@@ -332,7 +331,7 @@ def find_or_download_fastqs(sample_name, logger):
                     logger.info(f"None of the remote fastqs for {sample_name}_{tag} were matched")
                     logger.info(f"Downloading all remote fastqs for {sample_name}_{tag}")
                     for remote_key in remote_keys:
-                        future = executor.submit(download_and_decompress, bucket, remote_key, logger, tag)
+                        future = executor.submit(download_and_decompress, remote_key, logger, tag)
                         future_to_fq[future] = f'{sample_name}_{tag}'
             for future in as_completed(future_to_fq):
                 samplename_tag = future_to_fq[future]

--- a/tools/slims.py
+++ b/tools/slims.py
@@ -136,67 +136,78 @@ def download_hcp_fq(bucket, remote_key, logger, hcp_runtag):
     """Find and download fqs from HCP to fastqdir on seqstore for run"""
     config = read_config(WRAPPER_CONFIG_PATH)
 
-    queue = config["hcp"]["queue"]
-    download_script = os.path.abspath(config["hcp"]["download_script"])
-    hcp_downloads = config["hcp_download_dir"]
-    credentials_file = config['hcp']['credentials_file']
-    if not bucket:
-        bucket = config['hcp']['bucket']
-    connect_timeout = config["hcp"]["connect_timeout"]
-    read_timeout = config["hcp"]["read_timeout"]
-    retries = config["hcp"]["retries"]
+    # Read all download locations from the config
+    download_locations = config["hcp"]["download_locations"]
 
-    hcp_download_runpath = f'{hcp_downloads}/{hcp_runtag}' # This is the directory where the downloaded files will be stored
-    hcp_path = f'{hcp_download_runpath}/{os.path.basename(remote_key)}' # This is the complete path of the downloaded file
+    hcp_download_runpath = f'{config["hcp_download_dir"]}/{hcp_runtag}'  # Directory for downloaded files
+    hcp_path = f'{hcp_download_runpath}/{os.path.basename(remote_key)}'  # Full path of the downloaded file
 
-    if not os.path.exists(hcp_path):
-
-        os.makedirs(hcp_download_runpath, exist_ok=True)
-
-        # -cwd and -V make sure the script runs in the current directory and inherits the environment variables
-        qrsh = [
-            "qrsh",
-            "-q", queue,
-            "-N", f"hcp_download_{os.path.basename(remote_key)}",
-            "-pe", "mpi", "1",
-            "-now", "no",
-            "-cwd", "-V"
-        ]
-
-        # The download script takes the local path, remote key, and credentials_file (path) and bucket as arguments
-        main_args = ["python", download_script, "-l", hcp_path, "-r", remote_key, "-c", credentials_file, "-b", bucket]
-        optional_args = ["--connect_timeout", str(connect_timeout), "--read_timeout", str(read_timeout), "--retries", str(retries)]
-
-        # stitch and submit the command
-        cmd = qrsh + main_args + optional_args
-        logger.info(f'Downloading {os.path.basename(remote_key)} from HCP')
-        logger.info(f"Running hcp_download.py with args: {cmd}")
-        process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdout, stderr = process.communicate()
-        if stdout:
-            logger.info(stdout.decode('utf-8'))
-        if stderr:
-            logger.error(stderr.decode('utf-8'))
-
-        if process.returncode != 0:
-            logger.error(f"hcp_download.py failed with return code {process.returncode}")
-            raise RuntimeError(f"hcp_download.py failed with return code {process.returncode}")
-
-        # In rare cases, there may be a delay post-download before the file appears in the directory
-        start_time = time.time()
-        while not os.path.exists(hcp_path):
-            logger.info(f'Waiting for {hcp_path} to be downloaded...')
-            time.sleep(10)  # Wait for 10 seconds before checking again
-
-            # The delay should not be more than a minute
-            elapsed_time = time.time() - start_time
-            if elapsed_time > 60:
-                logger.error(f"The hcp_download finished successfully, but no file was found at {hcp_path}")
-                raise RuntimeError(f"The hcp_download finished successfully, but no file was found at {hcp_path}")
-
-    else:
+    if os.path.exists(hcp_path):
         logger.info(f'{os.path.basename(remote_key)} already exists in {hcp_download_runpath}')
-    return hcp_path
+        return hcp_path
+
+    os.makedirs(hcp_download_runpath, exist_ok=True)
+
+    # Iterate through the locations in the order specified in the config
+    for location_name, location_details in download_locations.items():
+        try:
+            bucket = location_details["bucket"]  # Bucket is specified in the config
+
+            logger.info(f"Trying to download from {location_name})")
+
+            # Construct the download command
+            qrsh = [
+                "qrsh",
+                "-q", config["hcp"]["queue"],
+                "-N", f"hcp_download_{os.path.basename(remote_key)}",
+                "-pe", "mpi", "1",
+                "-now", "no",
+                "-cwd", "-V"
+            ]
+
+            main_args = [
+                "python", os.path.abspath(config["hcp"]["download_script"]),
+                "-l", hcp_path,
+                "-r", remote_key,
+                "-c", location_details["credentials_file"],
+                "-b", bucket
+            ]
+
+            optional_args = [
+                "--connect_timeout", str(config["hcp"]["connect_timeout"]),
+                "--read_timeout", str(config["hcp"]["read_timeout"]),
+                "--retries", str(config["hcp"]["retries"])
+            ]
+
+            cmd = qrsh + main_args + optional_args
+            logger.info(f"Running hcp_download.py with args: {cmd}")
+
+            # Run the download command
+            process = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = process.communicate()
+
+            if stdout:
+                logger.info(stdout.decode('utf-8'))
+            if stderr:
+                logger.error(stderr.decode('utf-8'))
+
+            if process.returncode == 0:
+                # Verify the file exists after download
+                if os.path.exists(hcp_path):
+                    logger.info(f"Successfully downloaded {os.path.basename(remote_key)} from {url}")
+                    return hcp_path
+                else:
+                    logger.error(f"Download succeeded but file not found at {hcp_path}")
+                    raise RuntimeError(f"File not found after download: {hcp_path}")
+            else:
+                logger.warning(f"Failed to download from {location_name}")
+
+        except Exception as e:
+            logger.warning(f"Error while trying to download from {location_name}: {e}")
+
+    # If none of the locations worked, raise an error
+    logger.error(f"Failed to download {remote_key} from all locations.")
+    raise RuntimeError(f"Remote key {remote_key} could not be found on any of the specified locations.")
 
 
 def decompress_downloaded_fastq(complete_file_path, logger):


### PR DESCRIPTION
### The What

Allow wgs-somatic to download not just from hcp but also storage grid

### The Why

From May, the fastqs will start to be backed up on storage grid. From June everything will be migrated from hcp to storage grid. We will need to start enabling wgs-somatic to download from both locations.

### The How

Some things are still unclear:
- Will the migrated data have the correct path to the backup in slims (probably not)
- Will the migrated data have the correct bucket in the new backup endpoint (who knows)

Therefore:
1) Check storage grid with "illumina" bucket
2) Check storage grid with "data" bucket
3) Check hcp with "data" bucket
4) If downloading failed from all locations, raise an error

- The locations are specified in the config with the matching credentials file
- The wrapper iterates over the locations
- The download script first checks for the existence of the file and otherwise raises a FileNotFoundError()
- Once the file is successfully downloaded it will return the path to the file and proceed with decompression


### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [X] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Tests

Tried downloading from hcp, which worked. We will have to see in what way the data from hcp will migrate to sg1 and if it works once the fastqs get routinely uploaded to sg1 

