### PR TITLE
Sv filter manta

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,13 @@
 [submodule "workflows/scripts/annotate_manta_canvas"]
 	path = workflows/scripts/annotate_manta_canvas
 	url = https://github.com/ClinicalGenomicsGBG/annotate_manta_canvas.git
-        ignore = dirty
+	branch = master
+    ignore = dirty
 [submodule "workflows/scripts/b_allele_igv_plot"]
 	path = workflows/scripts/b_allele_igv_plot
 	url = https://github.com/ClinicalGenomicsGBG/b_allele_igv_plot.git
-        ignore = dirty        
+    ignore = dirty        
 [submodule "workflows/scripts/canvas_to_interpreter"]
 	path = workflows/scripts/canvas_to_interpreter
 	url = https://github.com/ClinicalGenomicsGBG/canvas_to_interpreter.git
-        ignore = dirty
+    ignore = dirty

--- a/configs/filters.yaml
+++ b/configs/filters.yaml
@@ -3,3 +3,10 @@ tmb_filter:
   min_mutant_allele_reads: 3
   min_coverage: 10
 
+sv_filter:
+  min_tumor_support: 3
+  max_normal_support: 2
+  # Other filters in filter_manta.py:
+  ## Need both paired and split reads
+  ## Remove duplicate (reciprocal) SVs
+  ## Filter to only keep "PASS"

--- a/workflows/rules/results_sharing/share_to_resultdir.smk
+++ b/workflows/rules/results_sharing/share_to_resultdir.smk
@@ -14,6 +14,7 @@ if tumorid:
                 expand("qc_report/{tumorname}_qc_stats.xlsx", tumorname=tumorname),
                 expand("{stype}/canvas/{sname}_CNV_somatic.vcf.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/canvas/{sname}_CNV_germline.vcf.xlsx", sname=normalid, stype=sampleconfig[normalname]["stype"]),
+                expand("{stype}/manta/{sname}_somatic_mantaSV.vcf", sname=tumorid, stype=sampleconfig[tumorname]["stype"]), 
                 expand("{stype}/manta/{sname}_somatic_mantaSV.vcf.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/manta/{sname}_somatic_mantaSV_Summary.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/dnascope/{sname}_{hgX}_SNV_CNV_germline.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=normalid, stype=sampleconfig[normalname]["stype"], hgX=reference),            
@@ -30,14 +31,6 @@ if tumorid:
                 expand("{stype}/reports/{sname}_REALIGNED.bam.tdf", sname=normalid, stype=sampleconfig[normalname]["stype"]),
                 expand("{stype}/reports/{sname}_baf.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/reports/{sname}_baf.igv", sname=normalid, stype=sampleconfig[normalname]["stype"]),
-                expand("{stype}/manta/{sname}_somatic_MantaBNDs.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-                #expand("{stype}/manta/{sname}_somatic_MantaBNDs.vcf.gzi.csi", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-                expand("{stype}/manta/{sname}_somatic_MantaNOBNDs.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-                #expand("{stype}/manta/{sname}_somatic_MantaNOBNDs.vcf.gzi.csi", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-                expand("{stype}/manta/{sname}_germline_MantaBNDs.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=normalid, stype=sampleconfig[normalname]["stype"]),
-                #expand("{stype}/manta/{sname}_germline_MantaBNDs.vcf.gzi.csi", sname=normalid, stype=sampleconfig[normalname]["stype"]),
-                expand("{stype}/manta/{sname}_germline_MantaNOBNDs.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=normalid, stype=sampleconfig[normalname]["stype"]),
-                #expand("{stype}/manta/{sname}_germline_MantaNOBNDs.vcf.gz.csi", sname=normalid, stype=sampleconfig[normalname]["stype"])
                 expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
@@ -57,6 +50,7 @@ if tumorid:
                 expand("{stype}/{caller}/{sname}_{vcftype}_refseq3kfilt.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], stype=sampleconfig[tumorname]["stype"], caller="tnscope", sname=tumorid, vcftype="somatic"),
                 expand("qc_report/{tumorname}_qc_stats.xlsx", tumorname=tumorname),
                 expand("{stype}/canvas/{sname}_CNV_germline.vcf.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+                expand("{stype}/manta/{sname}_somatic_mantaSV.vcf", sname=tumorid, stype=sampleconfig[tumorname]["stype"]), 
                 expand("{stype}/manta/{sname}_somatic_mantaSV.vcf.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/manta/{sname}_somatic_mantaSV_Summary.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/pindel/{sname}_pindel.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
@@ -66,10 +60,6 @@ if tumorid:
                 expand("{stype}/realign/{sname}_REALIGNED.{fmt}", fmt=["bam", "bam.bai", "cram", "cram.crai"], sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/reports/{sname}_REALIGNED.bam.tdf", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/reports/{sname}_baf.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-                expand("{stype}/manta/{sname}_somatic_MantaBNDs.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-                #expand("{stype}/manta/{sname}_somatic_MantaBNDs.vcf.gz.csi", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-                expand("{stype}/manta/{sname}_somatic_MantaNOBNDs.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-                #expand("{stype}/manta/{sname}_somatic_MantaNOBNDs.vcf.gzi.csi", sname=tumorid, stype=sampleconfig[tumorname]["stype"])
                 expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
@@ -93,10 +83,6 @@ else:
             expand("{stype}/canvas/{sname}_germline_CNV_called.seg", vartype="germline", sname=normalid, stype=sampleconfig[normalname]["stype"]),
             expand("{stype}/realign/{sname}_REALIGNED.{fmt}", fmt=["bam", "bam.bai", "cram", "cram.crai"], sname=normalid, stype=sampleconfig[normalname]["stype"]),
             expand("{stype}/reports/{sname}_REALIGNED.bam.tdf", sname=normalid, stype=sampleconfig[normalname]["stype"]),
-            expand("{stype}/manta/{sname}_germline_MantaBNDs.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=normalid, stype=sampleconfig[normalname]["stype"]),
-            #expand("{stype}/manta/{sname}_germline_MantaBNDs.vcf.gz.csi", sname=normalid, stype=sampleconfig[normalname]["stype"]),
-            expand("{stype}/manta/{sname}_germline_MantaNOBNDs.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=normalid, stype=sampleconfig[normalname]["stype"]),
-            #expand("{stype}/manta/{sname}_germline_MantaNOBNDs.vcf.csi", sname=normalid, stype=sampleconfig[normalname]["stype"]),
             expand("{stype}/reports/{sname}_baf.igv", sname=normalid, stype=sampleconfig[normalname]["stype"])
         output:
             "reporting/shared_result_files.txt"

--- a/workflows/rules/variantcalling/manta_hg38.smk
+++ b/workflows/rules/variantcalling/manta_hg38.smk
@@ -62,7 +62,7 @@ else:
             if not os.path.isfile(f"{wildcards.stype}/manta/results/variants/tumorSV.vcf"):
                 shell("gunzip {wildcards.stype}/manta/results/variants/tumorSV.vcf.gz")
             filter_vcf(
-                f"{wildcards.stype}/manta/results/variants/somaticSV.vcf",
+                f"{wildcards.stype}/manta/results/variants/tumorSV.vcf",
                 f"{output.sv_vcf}",
                 tumor_name=tumorname,
                 min_tumor_support=3

--- a/workflows/rules/variantcalling/manta_hg38.smk
+++ b/workflows/rules/variantcalling/manta_hg38.smk
@@ -17,6 +17,8 @@ if normalid:
             mantaconf = pipeconfig["rules"]["manta"]["mantaconf"],
             annotate = pipeconfig["rules"]["manta"].get("annotate", f"{ROOT_DIR}/workflows/scripts/annotate_manta_canvas/annotate_manta_canvas.py"),
             annotate_ref = pipeconfig["rules"]["manta"]["annotate_ref"],
+            min_tumor_support = filterconfig["sv_filter"]["min_tumor_support"],
+            max_normal_support = filterconfig["sv_filter"]["max_normal_support"],
         output:
             sv_vcf = temp("{stype}/manta/{sname}_somatic_mantaSV.vcf"),
             sv_xlsx = temp("{stype}/manta/{sname}_somatic_mantaSV.vcf.xlsx"),
@@ -34,8 +36,8 @@ if normalid:
                 f"{output.sv_vcf}",
                 tumor_name=tumorname,
                 normal_name=normalname,
-                min_tumor_support=3,
-                max_normal_support=2
+                min_tumor_support={params.min_tumor_support},
+                max_normal_support={params.max_normal_support}
                 )
             shell("{params.annotate} -v {output.sv_vcf} -g {params.annotate_ref} -o {wildcards.stype}/manta")
 else:
@@ -49,6 +51,7 @@ else:
             mantaconf = pipeconfig["rules"]["manta"]["mantaconf"],
             annotate = pipeconfig["rules"]["manta"].get("annotate", f"{ROOT_DIR}/workflows/scripts/annotate_manta_canvas/annotate_manta_canvas.py"),
             annotate_ref = pipeconfig["rules"]["manta"]["annotate_ref"],
+            min_tumor_support = filterconfig["sv_filter"]["min_tumor_support"],
         output:
             sv_vcf = temp("{stype}/manta/{sname}_somatic_mantaSV.vcf"),
             sv_xlsx = temp("{stype}/manta/{sname}_somatic_mantaSV.vcf.xlsx"),
@@ -65,7 +68,7 @@ else:
                 f"{wildcards.stype}/manta/results/variants/tumorSV.vcf",
                 f"{output.sv_vcf}",
                 tumor_name=tumorname,
-                min_tumor_support=3
+                min_tumor_support={params.min_tumor_support},
                 )
             shell("{params.annotate} -v {output.sv_vcf} -g {params.annotate_ref} -o {wildcards.stype}/manta")
 

--- a/workflows/scripts/filter_manta.py
+++ b/workflows/scripts/filter_manta.py
@@ -1,0 +1,117 @@
+import pysam
+import sys
+import argparse
+
+def is_reciprocal_pair(bnd_pairs, key, mate_key):
+    """
+    Check if the given key:value pair already exists as a value:key in the dictionary.
+    """
+    return mate_key in bnd_pairs and bnd_pairs[mate_key] == key
+
+def filter_vcf(input_vcf, output_vcf, tumor_name=None, normal_name=None, min_tumor_support=3, max_normal_support=2):
+    """
+    Filters a VCF file based on the following criteria:
+    - FILTER column must be "PASS".
+    - Both PR and SR fields must be present.
+    - At least `min_tumor_support` reads supporting the variant in the tumor.
+    - If a normal sample is provided:
+        - No more than `max_normal_support` reads supporting the variant in the normal.
+    - Removes duplicate breakends (reciprocal variants).
+    """
+    # Dictionary to track reciprocal breakends
+    bnd_pairs = {}
+
+    with pysam.VariantFile(input_vcf) as vcf_in, pysam.VariantFile(output_vcf, "w", header=vcf_in.header) as vcf_out:
+        for record in vcf_in:
+            # Check if the variant passes the FILTER column
+            if "PASS" not in record.filter.keys():
+                continue
+
+            # Extract tumor sample data
+            if tumor_name:
+                try:
+                    tumor_sample = record.samples[tumor_name]
+                except KeyError:
+                    continue  # Skip if tumor sample is missing
+
+                # Ensure both PR and SR are present in the tumor sample
+                if "PR" not in tumor_sample or "SR" not in tumor_sample:
+                    continue
+
+                # Extract PR and SR values for the tumor sample
+                tumor_pr, tumor_sr = tumor_sample["PR"], tumor_sample["SR"]
+                tumor_support = tumor_pr[1] + tumor_sr[1]
+
+                # Apply the tumor support filter
+                if tumor_support < min_tumor_support:
+                    continue
+
+            # If a normal sample is provided, apply normal-specific filters
+            if normal_name:
+                try:
+                    normal_sample = record.samples[normal_name]
+                except KeyError:
+                    continue  # Skip if normal sample is missing
+
+                # Ensure both PR and SR are present in the normal sample
+                if "PR" not in normal_sample or "SR" not in normal_sample:
+                    continue
+
+                # Extract PR and SR values for the normal sample
+                normal_pr, normal_sr = normal_sample["PR"], normal_sample["SR"]
+                normal_support = normal_pr[1] + normal_sr[1]
+
+                if tumor_name:
+                    # Apply the normal support filter
+                    if normal_support > max_normal_support:
+                        continue
+
+            # Handle reciprocal breakends (BNDs)
+            if record.info.get("SVTYPE") == "BND" and "MATEID" in record.info:
+                # Create a unique key for the variant
+                key = f"{record.chrom}:{record.pos}"
+                mate_key = None
+
+                # Extract the breakpoint coordinates from the ALT field
+                alt_field = str(record.alts[0])
+                if "[" in alt_field or "]" in alt_field:
+                    # Split by square brackets to extract the mate position
+                    parts = alt_field.replace("[", "]").split("]")
+                    for part in parts:
+                        if ":" in part:
+                            mate_key = part.strip()
+                            print(f"Mate key: {mate_key}")  # Debugging line
+                            break
+
+                # Check if the reciprocal pair already exists
+                if is_reciprocal_pair(bnd_pairs, key, mate_key):
+                    print(f"Skipping duplicate BND: {key} and {mate_key}")  # Debugging line
+                    continue  # Skip this variant as its reciprocal pair has already been processed
+
+                # Add the current key and mate key to the dictionary
+                bnd_pairs[key] = mate_key
+                bnd_pairs[mate_key] = key
+                print(f"Adding BND pair: {key} and {mate_key}")  # Debugging line
+
+            # Write the record to the output VCF
+            vcf_out.write(record)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Filter a VCF file based on tumor and normal sample criteria.")
+    parser.add_argument("input_vcf", help="Input VCF file")
+    parser.add_argument("output_vcf", help="Output VCF file")
+    parser.add_argument("--tumor_name", help="Tumor sample name")
+    parser.add_argument("--normal_name", help="Normal sample name (optional)", default=None)
+    parser.add_argument("--min_tumor_support", type=int, help="Minimum tumor support (default: 3)", default=3)
+    parser.add_argument("--max_normal_support", type=int, help="Maximum normal support (default: 2)", default=2)
+
+    args = parser.parse_args()
+
+    filter_vcf(
+        input_vcf=args.input_vcf,
+        output_vcf=args.output_vcf,
+        tumor_name=args.tumor_name,
+        normal_name=args.normal_name,
+        min_tumor_support=args.min_tumor_support,
+        max_normal_support=args.max_normal_support,
+    )

--- a/workflows/scripts/filter_manta.py
+++ b/workflows/scripts/filter_manta.py
@@ -1,12 +1,13 @@
 import pysam
-import sys
 import argparse
+
 
 def is_reciprocal_pair(bnd_pairs, key, mate_key):
     """
     Check if the given key:value pair already exists as a value:key in the dictionary.
     """
     return mate_key in bnd_pairs and bnd_pairs[mate_key] == key
+
 
 def filter_vcf(input_vcf, output_vcf, tumor_name=None, normal_name=None, min_tumor_support=3, max_normal_support=2):
     """
@@ -80,21 +81,19 @@ def filter_vcf(input_vcf, output_vcf, tumor_name=None, normal_name=None, min_tum
                     for part in parts:
                         if ":" in part:
                             mate_key = part.strip()
-                            print(f"Mate key: {mate_key}")  # Debugging line
                             break
 
                 # Check if the reciprocal pair already exists
                 if is_reciprocal_pair(bnd_pairs, key, mate_key):
-                    print(f"Skipping duplicate BND: {key} and {mate_key}")  # Debugging line
                     continue  # Skip this variant as its reciprocal pair has already been processed
 
                 # Add the current key and mate key to the dictionary
                 bnd_pairs[key] = mate_key
                 bnd_pairs[mate_key] = key
-                print(f"Adding BND pair: {key} and {mate_key}")  # Debugging line
 
             # Write the record to the output VCF
             vcf_out.write(record)
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Filter a VCF file based on tumor and normal sample criteria.")

--- a/workflows/scripts/filter_manta.py
+++ b/workflows/scripts/filter_manta.py
@@ -83,6 +83,11 @@ def filter_vcf(input_vcf, output_vcf, tumor_name=None, normal_name=None, min_tum
                             mate_key = part.strip()
                             break
 
+                # Ensure mate_key is valid before proceeding
+                if mate_key is None:
+                    print(f"Warning: Unable to parse mate key for variant {key}. Skipping.")
+                    continue
+
                 # Check if the reciprocal pair already exists
                 if is_reciprocal_pair(bnd_pairs, key, mate_key):
                     continue  # Skip this variant as its reciprocal pair has already been processed


### PR DESCRIPTION
### The What

Filter the structural variant output from manta to allow only variants with:
- must "PASS" manta filters (default?)
- need evidence from both paired reads and split reads supporting the variant
- at least 3 tumor reads supporting the variant
- at most 2 normal reads supporting the variant (for paired tumor-normal runs)
- remove reciprocal breakends (duplicates)

### The Why

The geneticists believe variants that do not pass these filters are not of high enough confidence

### The How

python script "filter_manta.py" takes care of most of the filtering. It is possible to adjust the number of supporting reads, which also makes the rule more readable. The output from the python script is a vcf file (using pysam; already in the wgs-somatic env). 

### Other changes

- Stopped running manta on germline (only used for output, but output not used by geneticists)
- Removed splitting vcf into Bnd/NoBnd, and removed from output as well
- Added the somatic (filtered) vcf to the output, for potentially uploading to QCI

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [X] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

### Tests

Tested tumor-only and tumor-normal
