### PR TITLE
Fix  more robust download

### DIFF
--- a/tools/hcp_download.py
+++ b/tools/hcp_download.py
@@ -86,7 +86,7 @@ def setup_logger(name):
     return logger
 
 
-def download_file(local_path, remote_path, credentials_path, bucket, connect_timeout, read_timeout, retries):
+def download_file(local_path, remote_path, credentials_path, bucket, connect_timeout, read_timeout, retries, threads):
     """
     Download a file from an S3 bucket.
 
@@ -121,7 +121,7 @@ def download_file(local_path, remote_path, credentials_path, bucket, connect_tim
         # Download the file
         try:
             config = TransferConfig(
-                max_concurrency=4,
+                max_concurrency=threads,
                 use_threads=True
             )
             s3.meta.client.download_file(bucket, remote_path, local_path, Config=config)
@@ -162,10 +162,11 @@ def main():
     parser.add_argument("--connect_timeout", help="Time (s) to establish connection.", required=False, type=int, default=10)
     parser.add_argument("--read_timeout", help="Time (s) to wait for a response.", required=False, type=int, default=30)
     parser.add_argument("--retries", help="Number of retries.", required=False, type=int, default=20)
+    parser.add_argument("--threads", help="Number of threads to use for download.", required=False, type=int, default=4)
     args = parser.parse_args()
 
     try:
-        download_file(args.local_path, args.remote_path, args.credentials_path, args.bucket, args.connect_timeout, args.read_timeout, args.retries)
+        download_file(args.local_path, args.remote_path, args.credentials_path, args.bucket, args.connect_timeout, args.read_timeout, args.retries, args.threads)
     except FileNotFoundError as e:
         print(f"File not found: {e}")
         sys.exit(1)  # Exit with a non-zero code for file not found

--- a/tools/hcp_download.py
+++ b/tools/hcp_download.py
@@ -125,7 +125,7 @@ def download_file(local_path, remote_path, credentials_path, bucket, connect_tim
                 use_threads=True
             )
             s3.meta.client.download_file(bucket, remote_path, local_path, Config=config)
-            logger.debug("File downloaded successfully with threads.")
+            logger.info("File downloaded successfully with threads.")
         except botocore.exceptions.ClientError as e:
             logger.warning(f"Threaded download failed: {e}. Retrying without threads...")
 
@@ -140,6 +140,9 @@ def download_file(local_path, remote_path, credentials_path, bucket, connect_tim
             except Exception as e:
                 logger.error(f"Fallback download also failed: {e}")
                 raise
+        except Exception as e:
+            logger.error(f"An unexpected error occurred while performing threaded download: {e}")
+            raise
 
     except FileNotFoundError as e:
         # Propagate the FileNotFoundError explicitly
@@ -169,6 +172,7 @@ def main():
     except Exception as e:
         print(f"An error occurred: {e}")
         sys.exit(2)  # Exit with a different non-zero code for other errors
+
 
 if __name__ == '__main__':
     try:


### PR DESCRIPTION
### The What

Make sure we do not overload the hcp when downloading

### The Why

I was getting a bunch of 503 errors

### The How

- Use TransferConfig from boto3.s3.transfer to reduce the multithreading
- If download with (moderate) multithreading fails (e.g. 503), download with single thread

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

