### PR TITLE
Adjust controlfreec bam

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ novaseq_runlist.txt
 workflows/scripts/annotate_manta/genelist.txt
 workflows/scripts/annotate_manta/genelist_old.txt
 *.swp
+tmp*

--- a/configs/config_hg38.json
+++ b/configs/config_hg38.json
@@ -111,7 +111,7 @@
             "ploidy": ["free","2"],
             "chrLenFile": "/clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs.fai",
             "chrFiles": "/clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs/",
-            "SNPfile": "/clinical/exec/wgs_somatic/dependencies/control_freec/common_dnSNP156_hg38.vcf.gz",
+            "mappability": "/clinical/exec/wgs_somatic/dependencies/control_freec/out100m2_hg38.gem",
             "cytoBandIdeo": "/clinical/exec/wgs_somatic/dependencies/control_freec/cytoBandIdeo.txt",
             "shadow": "minimal"
         },

--- a/workflows/rules/qc/aggregate_qc.smk
+++ b/workflows/rules/qc/aggregate_qc.smk
@@ -21,7 +21,7 @@ if tumorid:
                 tmb = expand("{stype}/reports/{sname}_tmb.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
                 msi_filtered = expand("{stype}/msi/{sname}_msi_filtered.txt", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 msi = expand("{stype}/msi/{sname}_msi.txt", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-                tumor_info_files = expand("{stype}/control-freec_{ploidy}/{sname}.pileup_info.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid, ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                tumor_info_files = expand("{stype}/control-freec_{ploidy}/{sname}_REALIGNED.bam_info.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid, ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
             output:
                 temp("qc_report/{tumorname}_qc_stats.xlsx")
             run:
@@ -38,7 +38,7 @@ if tumorid:
                 tumorvcf = expand("{stype}/dnascope/{sname}_germline_SNVsOnly.recode.vcf", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
                 insilicofile = expand("{stype}/insilico/{insiliconame}/{sname}_{insiliconame}_genes_below10x.xlsx", stype=sampleconfig[tumorname]["stype"], insiliconame=sampleconfig["insilico"], sname=tumorid),
                 tmb = expand("{stype}/reports/{sname}_tmb.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
-                tumor_info_files = expand("{stype}/control-freec_{ploidy}/{sname}.pileup_info.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid, ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                tumor_info_files = expand("{stype}/control-freec_{ploidy}/{sname}_REALIGNED.bam_info.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid, ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
             output:
                 temp("qc_report/{tumorname}_qc_stats.xlsx")
             run:

--- a/workflows/rules/results_sharing/share_to_resultdir.smk
+++ b/workflows/rules/results_sharing/share_to_resultdir.smk
@@ -33,9 +33,6 @@ if tumorid:
                 expand("{stype}/reports/{sname}_baf.igv", sname=normalid, stype=sampleconfig[normalname]["stype"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-                #expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-                #expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-                expand("{stype}/ascat/{sname}_ascat_plot.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
             output:
                 "reporting/shared_result_files.txt"
             run:

--- a/workflows/rules/results_sharing/share_to_resultdir.smk
+++ b/workflows/rules/results_sharing/share_to_resultdir.smk
@@ -33,10 +33,9 @@ if tumorid:
                 expand("{stype}/reports/{sname}_baf.igv", sname=normalid, stype=sampleconfig[normalname]["stype"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_BAF.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                #expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                #expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                expand("{stype}/ascat/{sname}_ascat_plot.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
             output:
                 "reporting/shared_result_files.txt"
             run:
@@ -62,7 +61,6 @@ if tumorid:
                 expand("{stype}/reports/{sname}_baf.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
             output:
                 "reporting/shared_result_files.txt"
             run:

--- a/workflows/rules/results_sharing/share_to_resultdir.smk
+++ b/workflows/rules/results_sharing/share_to_resultdir.smk
@@ -31,8 +31,8 @@ if tumorid:
                 expand("{stype}/reports/{sname}_REALIGNED.bam.tdf", sname=normalid, stype=sampleconfig[normalname]["stype"]),
                 expand("{stype}/reports/{sname}_baf.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/reports/{sname}_baf.igv", sname=normalid, stype=sampleconfig[normalname]["stype"]),
-                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 #expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 #expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/ascat/{sname}_ascat_plot.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
@@ -59,8 +59,8 @@ if tumorid:
                 expand("{stype}/realign/{sname}_REALIGNED.{fmt}", fmt=["bam", "bam.bai", "cram", "cram.crai"], sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/reports/{sname}_REALIGNED.bam.tdf", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/reports/{sname}_baf.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-                expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
             output:
                 "reporting/shared_result_files.txt"
             run:

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -40,8 +40,8 @@ if normalid:
         singularity:
             pipeconfig["singularities"]["control-freec"]["sing"]
         output:
-            ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png"),
-            ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg"),
+            ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png"),
+            ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg"),
             #normal_ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.png"),
             #normal_ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.seg"),
         shadow:
@@ -93,8 +93,8 @@ else:
         singularity:
             pipeconfig["singularities"]["control-freec"]["sing"]
         output:
-            ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png"),
-            ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg"),
+            ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png"),
+            ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg"),
         shadow:
             pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
         shell:

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -48,9 +48,9 @@ if normalid:
             pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
         shell:
             """
-            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg} {output.BAF_igv}
+            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg}
             """
-            #Rscript {params.plot_script} {wildcards.sname} {input.normal_ratio} {input.normal_BAF} {params.fai} {params.cytoBandIdeo} {output.normal_ratio_plot} {output.normal_ratio_seg} {output.normal_BAF_igv}
+            #Rscript {params.plot_script} {wildcards.sname} {input.normal_ratio} {input.normal_BAF} {params.fai} {params.cytoBandIdeo} {output.normal_ratio_plot} {output.normal_ratio_seg}
             
 
 
@@ -99,5 +99,5 @@ else:
             pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
         shell:
             """
-            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg} {output.BAF_igv}
+            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg}
             """

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -1,8 +1,8 @@
 if normalid:
     rule control_freec_run:
         input:
-            tumor_pileup = expand("{stype}/realign/{sname}_REALIGNED.bam", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-            normal_pileup = expand("{stype}/realign/{sname}_REALIGNED.bam", sname=normalid, stype=sampleconfig[normalname]["stype"]),
+            tumor_bam = expand("{stype}/realign/{sname}_REALIGNED.bam", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+            normal_bam = expand("{stype}/realign/{sname}_REALIGNED.bam", sname=normalid, stype=sampleconfig[normalname]["stype"]),
         params:
             config_template = pipeconfig["rules"]["control-freec"].get("config_template", f"{ROOT_DIR}/workflows/scripts/control_freec_config.txt"),
             edit_config = pipeconfig["rules"]["control-freec"].get("edit_config", f"{ROOT_DIR}/workflows/scripts/control_freec_edit_config.py"),
@@ -17,54 +17,26 @@ if normalid:
         output:
             config = temp("{stype}/control-freec_{ploidy}/{sname}.config"),
             tumor_ratio = temp("{stype}/control-freec_{ploidy}/{sname}_REALIGNED.bam_ratio.txt"),
-            #normal_ratio = temp("{stype}/control-freec_{ploidy}/{sname}_REALIGNED.bam_normal_ratio.txt"),
             info = temp("{stype}/control-freec_{ploidy}/{sname}_REALIGNED.bam_info.txt"),
-        #shadow:
-        #    pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
-        shell:
-            """
-            python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_pileup} {input.normal_pileup} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config}
-            freec -conf {output.config}
-            """
-
-    rule control_freec_plot:
-        input:
-            ratio = "{stype}/control-freec_{ploidy}/{sname}_REALIGNED.bam_ratio.txt",
-            #normal_ratio = "{stype}/control-freec_{ploidy}/{sname}_REALIGNED.bam_normal_ratio.txt",
-            BAF = expand("{stype}/reports/{sname}_baf.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-            normal_BAF = expand("{stype}/reports/{sname}_baf.igv", sname=normalid, stype=sampleconfig[normalname]["stype"]),
-        params:
-            plot_script = pipeconfig["rules"]["control-freec"].get("plot_script", f"{ROOT_DIR}/workflows/scripts/control_freec_makeGraph3.0.R"),
-            fai =  pipeconfig["referencefai"],
-            cytoBandIdeo = pipeconfig["rules"]["control-freec"]["cytoBandIdeo"],
-        singularity:
-            pipeconfig["singularities"]["control-freec"]["sing"]
-        output:
-            ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png"),
-            ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg"),
-            #normal_ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.png"),
-            #normal_ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_normal_ratio.seg"),
         shadow:
             pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
         shell:
             """
-            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg}
+            python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_bam} {input.normal_bam} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config}
+            freec -conf {output.config}
             """
-            #Rscript {params.plot_script} {wildcards.sname} {input.normal_ratio} {input.normal_BAF} {params.fai} {params.cytoBandIdeo} {output.normal_ratio_plot} {output.normal_ratio_seg}
-            
-
 
 else:
     rule control_freec_run:
         input:
-            tumor_pileup = expand("{stype}/realign/{sname}_REALIGNED.bam", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+            tumor_bam = expand("{stype}/realign/{sname}_REALIGNED.bam", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
         params:
             config_template = pipeconfig["rules"]["control-freec"].get("config_template", f"{ROOT_DIR}/workflows/scripts/control_freec_config.txt"),
             edit_config = pipeconfig["rules"]["control-freec"].get("edit_config", f"{ROOT_DIR}/workflows/scripts/control_freec_edit_config.py"),
             chrLenFile = pipeconfig["rules"]["control-freec"]["chrLenFile"],
             chrFiles = pipeconfig["rules"]["control-freec"]["chrFiles"],
             mappability = pipeconfig["rules"]["control-freec"]["mappability"],
-            normal_pileup = "None",
+            normal_bam = "None",
         singularity:
             pipeconfig["singularities"]["control-freec"]["sing"]
         threads:
@@ -78,26 +50,26 @@ else:
             pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
         shell:
             """
-            python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_pileup} {params.normal_pileup} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config}
+            python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_bam} {params.normal_bam} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config}
             freec -conf {output.config}
             """
 
-    rule control_freec_plot:
-        input:
-            ratio = "{stype}/control-freec_{ploidy}/{sname}_REALIGNED.bam_ratio.txt",
-            BAF = expand("{stype}/reports/{sname}_baf.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-        params:
-            plot_script = pipeconfig["rules"]["control-freec"].get("plot_script", f"{ROOT_DIR}/workflows/scripts/control_freec_makeGraph3.0.R"),
-            fai =  pipeconfig["referencefai"],
-            cytoBandIdeo = pipeconfig["rules"]["control-freec"]["cytoBandIdeo"],
-        singularity:
-            pipeconfig["singularities"]["control-freec"]["sing"]
-        output:
-            ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png"),
-            ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg"),
-        shadow:
-            pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
-        shell:
-            """
-            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg}
-            """
+rule control_freec_plot:
+    input:
+        ratio = "{stype}/control-freec_{ploidy}/{sname}_REALIGNED.bam_ratio.txt",
+        BAF = expand("{stype}/reports/{sname}_baf.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+    params:
+        plot_script = pipeconfig["rules"]["control-freec"].get("plot_script", f"{ROOT_DIR}/workflows/scripts/control_freec_makeGraph3.0.R"),
+        fai =  pipeconfig["referencefai"],
+        cytoBandIdeo = pipeconfig["rules"]["control-freec"]["cytoBandIdeo"],
+    singularity:
+        pipeconfig["singularities"]["control-freec"]["sing"]
+    output:
+        ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png"),
+        ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg"),
+    shadow:
+        pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
+    shell:
+        """
+        Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg}
+        """

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -44,7 +44,6 @@ else:
         output:
             config = temp("{stype}/control-freec_{ploidy}/{sname}.config"),
             tumor_ratio = temp("{stype}/control-freec_{ploidy}/{sname}_REALIGNED.bam_ratio.txt"),
-            tumor_BAF = temp("{stype}/control-freec_{ploidy}/{sname}_REALIGNED.bam_BAF.txt"),
             info = temp("{stype}/control-freec_{ploidy}/{sname}_REALIGNED.bam_info.txt"),
         shadow:
             pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))

--- a/workflows/scripts/control_freec_config.txt
+++ b/workflows/scripts/control_freec_config.txt
@@ -6,6 +6,7 @@
 
 chrLenFile = /clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs.fai
 chrFiles = /clinical/exec/wgs_somatic/dependencies/control_freec/hg38_chrs/
+gemMappabilityFile = /clinical/exec/wgs_somatic/dependencies/control_freec/out100m2_hg38.gem
 ploidy = 1,2,3,4
 outputDir = ./
 maxThreads = 4
@@ -40,20 +41,20 @@ BedGraphOutput=FALSE
 [sample]
 
 mateFile = 
-inputFormat = pileup
+inputFormat = BAM
 mateOrientation = FR
 
 [control]
 
 mateFile = 
-inputFormat = pileup
+inputFormat = BAM
 mateOrientation = FR
 
-[BAF]
+#[BAF]
 
-SNPfile = /clinical/exec/wgs_somatic/dependencies/control_freec/common_dnSNP156_hg38.vcf.gz
+#SNPfile = /clinical/exec/wgs_somatic/dependencies/control_freec/common_dnSNP156_hg38.vcf.gz
 
-[target]
+#[target]
 
 ##use a tab-delimited .BED file to specify capture regions (control dataset is needed to use this option):
 

--- a/workflows/scripts/control_freec_edit_config.py
+++ b/workflows/scripts/control_freec_edit_config.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 
-def edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile, chrFiles, SNPfile, threads, output_config):
+def edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile, chrFiles, mappability, threads, output_config):
     
     outdir = os.path.dirname(output_config)
     os.makedirs(outdir, exist_ok=True)
@@ -22,8 +22,8 @@ def edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile
         config_data = re.sub(r'(\[control\]\n\nmateFile =).*', f'\\1 {normal_pileup}', config_data, flags=re.MULTILINE)
     config_data = re.sub(r'^chrLenFile =.*', f'chrLenFile = {chrLenFile}', config_data, flags=re.MULTILINE)
     config_data = re.sub(r'^chrFiles =.*', f'chrFiles = {chrFiles}', config_data, flags=re.MULTILINE)
+    config_data = re.sub(r'^gemMappabilityFile =.*', f'gemMappabilityFile = {mappability}', config_data, flags=re.MULTILINE)
     config_data = re.sub(r'^maxThreads =.*', f'maxThreads = {threads}', config_data, flags=re.MULTILINE)
-    config_data = re.sub(r'^SNPfile =.*', f'SNPfile = {SNPfile}', config_data, flags=re.MULTILINE)
     with open(output_config, 'w') as file:
         file.write(config_data)
 
@@ -37,8 +37,8 @@ if __name__ == "__main__":
     normal_pileup = sys.argv[4]
     chrLenFile = sys.argv[5]
     chrFiles = sys.argv[6]
-    SNPfile = sys.argv[7]
+    mappability = sys.argv[7]
     threads = sys.argv[8]
     output_config = sys.argv[9]
 
-    edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile, chrFiles, SNPfile, threads, output_config)
+    edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile, chrFiles, mappability, threads, output_config)

--- a/workflows/scripts/control_freec_makeGraph3.0.R
+++ b/workflows/scripts/control_freec_makeGraph3.0.R
@@ -30,7 +30,6 @@ fai_file <- args[4]               # FAI file (genome index) used to adjust chrom
 cytoband <- args[5]               # Cytoband file (chromosome banding information)
 output_ratio_plot <- args[6]      # Output file for the ratio plot
 output_ratio_seg <- args[7]       # Output file for the ratio segmentation
-output_BAF_igv <- args[8]         # Output file for the BAF IGV track
 
 # Check if the FAI file exists
 if (!file.exists(fai_file)) {

--- a/workflows/scripts/control_freec_makeGraph3.0.R
+++ b/workflows/scripts/control_freec_makeGraph3.0.R
@@ -108,7 +108,7 @@ labels <- c(as.character(breaks[-length(breaks)]), paste0(">", max(breaks) - 1))
 Ratio_plot <- ggplot(fai) +                                              
   geom_rect(data = cytoband, aes(xmin = adjStart, xmax = adjEnd, ymin = -(max_cutoff * ploidy * 0.035), ymax = -(max_cutoff * ploidy * 0.01), fill = color)) +
   geom_point(data = ratio_adjusted, aes(adjStart, corr_ratio, color = color), shape = '.') +
-  geom_point(data = ratio_adjusted, aes(adjStart, CopyNumber_adj), shape = '.', col = "#00000050") +
+  geom_point(data = ratio_adjusted, aes(adjStart, CopyNumber_adj), shape = '.', col = "#00000070") +
   geom_vline(aes(xintercept = start), col = "grey") +
   geom_text(aes(label = chr, x = middle, y = Inf), vjust = 1, size = 3) +
   scale_y_continuous("Copy number",
@@ -132,7 +132,7 @@ BAF_adjusted_red <- BAF_adjusted %>%
 # Create the BAF plot
 BAF_plot <- ggplot(fai) +                                              
   geom_vline(aes(xintercept = start), col = "grey") +
-  geom_point(data = BAF_adjusted_red, aes(adjPosition, BAF), shape = '.', col = "#00000010") +
+  geom_point(data = BAF_adjusted_red, aes(adjPosition, BAF), shape = '.', col = "#00000020") +
   geom_text(aes(label = chr, x = middle, y = Inf), vjust = 1, size = 3) +
   scale_y_continuous("BAF", limits = c(0, 1), expand = expansion(mult = 0.1)) +
   theme(axis.title.x = element_blank(), axis.text.x = element_blank(), axis.ticks.x = element_blank())

--- a/workflows/scripts/control_freec_makeGraph3.0.R
+++ b/workflows/scripts/control_freec_makeGraph3.0.R
@@ -44,7 +44,8 @@ ratio <- data.frame(read.table(ratio_file, header=TRUE))
 
 # Read the BAF data into a data frame, skipping header lines starting with '#'
 BAF <- read.table(BAF_file, header = FALSE, comment.char = "#", sep = "\t",
-                  col.names = c("Chromosome", "Start", "End", "Features", "BAF"))
+                  col.names = c("Chromosome", "Start", "End", "Features", "BAF"))%>%
+  mutate(Chromosome = substr(Chromosome, 4, 30)) # Remove the "chr" prefix from chromosome names
 
 
 # Read the FAI file and process it

--- a/workflows/scripts/control_freec_makeGraph3.0.R
+++ b/workflows/scripts/control_freec_makeGraph3.0.R
@@ -146,6 +146,7 @@ dev.off()
 writeLines("#track graphType=points maxHeightPixels=300:300:300 color=0,0,0 altColor=0,0,0", con = output_ratio_seg)
 ratio_adjusted %>%
   mutate(Sample = tumor_id,
-         Chromosome = paste0("chr", Chromosome)) %>%
-  select(Sample, Chromosome, Start, End, corr_ratio) %>%
+         Chromosome = paste0("chr", Chromosome),
+         Copynumber = Ratio * ploidy) %>%
+  select(Sample, Chromosome, Start, End, Copynumber) %>%
   write.table(output_ratio_seg, sep = "\t", quote = FALSE, row.names = FALSE, col.names = TRUE, append = TRUE)

--- a/workflows/tn_workflow.smk
+++ b/workflows/tn_workflow.smk
@@ -64,8 +64,8 @@ rule tn_workflow:
         expand("{stype}/realign/{sname}_REALIGNED.{fmt}", fmt=["cram", "cram.crai"], sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
         expand("{stype}/realign/{sname}_REALIGNED.{fmt}", fmt=["cram", "cram.crai"], sname=normalid, stype=sampleconfig[normalname]["stype"]),
         expand("{stype}/pindel/{sname}_pindel.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+        expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+        expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
         "reporting/shared_result_files.txt",
         insilico_files = get_insilico
     output:

--- a/workflows/tn_workflow.smk
+++ b/workflows/tn_workflow.smk
@@ -66,7 +66,6 @@ rule tn_workflow:
         expand("{stype}/pindel/{sname}_pindel.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
         expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
         expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
         "reporting/shared_result_files.txt",
         insilico_files = get_insilico
     output:

--- a/workflows/tumoronly_workflow.smk
+++ b/workflows/tumoronly_workflow.smk
@@ -54,8 +54,8 @@ rule tumoronly_workflow:
         expand("{stype}/reports/{sname}_REALIGNED.bam.tdf", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
         expand("{stype}/realign/{sname}_REALIGNED.{fmt}", fmt=["cram", "cram.crai"], sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
         expand("{stype}/pindel/{sname}_pindel.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+        expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+        expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
         "reporting/shared_result_files.txt",
         insilico_files = get_insilico
     output:

--- a/workflows/tumoronly_workflow.smk
+++ b/workflows/tumoronly_workflow.smk
@@ -56,7 +56,6 @@ rule tumoronly_workflow:
         expand("{stype}/pindel/{sname}_pindel.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
         expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
         expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_ratio.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-        expand("{stype}/control-freec_{ploidy}/{sname}_ploidy{ploidy}_BAF.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
         "reporting/shared_result_files.txt",
         insilico_files = get_insilico
     output:


### PR DESCRIPTION
### The What

- Use .bam files instead of .pileup files for running control-freec
  - Without the pileup control-freec does no BAF calculation
    - Use BAF from ballele.smk rule for plot
- Use mappability with control-freec to reduce noise

### The Why

- Generating the pileups takes a very long time
- The pileups can become large, generating other issues

### The How

- Adjust rules and configs to use the .bam files
- Adjust the plotting script to accommodate for the new input files

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [X] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

### Tests

- Tested tumor-normal and tumor-only
- Made sure myc-n amplification is still visible
