### PR TITLE
Add ascat again and remove automated normal-only start

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -124,6 +124,7 @@ if tumorid:
     include:        "workflows/rules/small_tools/tmb_calculation.smk"
     include:        "workflows/rules/small_tools/msi.smk"
     include:        "workflows/rules/variantcalling/control-freec.smk"
+    include:        "workflows/rules/variantcalling/ascat.smk"
 include:        "workflows/rules/variantcalling/dnascope.smk"
 include:        "workflows/rules/small_tools/ballele.smk"
 include:        "workflows/rules/variantcalling/canvas.smk"

--- a/configs/cluster.yaml
+++ b/configs/cluster.yaml
@@ -111,3 +111,6 @@ control_freec_plot:
     name: "WGSsomatic_{rule}_ploidy{wildcards.ploidy}_{wildcards.sname}"
     output: "WGSsomatic_{rule}_ploidy{wildcards.ploidy}_{wildcards.sname}.stdout"
     error: "WGSsomatic_{rule}_ploidy{wildcards.ploidy}_{wildcards.sname}.stderr"
+
+ascat_run:
+    threads: 16

--- a/configs/config_hg38.json
+++ b/configs/config_hg38.json
@@ -3,6 +3,10 @@
     "referencefai": "/clinical/exec/wgs_somatic/dependencies/ncbi/hg38/GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.fai",
     "singularities":
     {
+        "ascat":
+        {
+            "sing": "/clinical/exec/wgs_somatic/dependencies/singularities/ascat-3.2.0.sif"
+        },
         "canvas":
         {
             "sing": "/clinical/exec/wgs_somatic/dependencies/singularities/canvas_hg38_v1.40.0.1613.sif",
@@ -57,6 +61,14 @@
         "recal":
         {
             "outputdir": "recal"
+        },
+        "ascat_run":{
+            "allelecounter_exe": "/opt/conda/bin/alleleCounter",
+            "alleles_prefix": "/clinical/exec/wgs_somatic/dependencies/ascat/G1000_alleles_hg38_chr",
+            "loci_prefix": "/clinical/exec/wgs_somatic/dependencies/ascat/G1000_loci_hg38_chr",
+            "genome_version": "hg38",
+            "gc_content_file": "/clinical/exec/wgs_somatic/dependencies/ascat/GC_G1000_hg38.txt",
+            "replic_timing_file": "/clinical/exec/wgs_somatic/dependencies/ascat/RT_G1000_hg38.txt"
         },
         "insilico":
         {

--- a/singularities/ascat-3.2.0/ascat-3.2.0.def
+++ b/singularities/ascat-3.2.0/ascat-3.2.0.def
@@ -10,6 +10,7 @@ From: mambaorg/micromamba
 %post -c /bin/bash
     micromamba install -n base --file ascat-3.2.0.yaml && \
     micromamba clean --all --yes
+    # After installation, the alleleCounter executable is located in /opt/conda/bin/alleleCounter
 
 %runscript
     #!/bin/bash

--- a/singularities/ascat-3.2.0/ascat-3.2.0.def
+++ b/singularities/ascat-3.2.0/ascat-3.2.0.def
@@ -1,0 +1,18 @@
+Bootstrap: docker
+From: mambaorg/micromamba
+
+%files
+    ascat-3.2.0.yaml /ascat-3.2.0.yaml
+
+%environment
+    export PATH="${MAMBA_ROOT_PREFIX}/bin:$PATH"
+
+%post -c /bin/bash
+    micromamba install -n base --file ascat-3.2.0.yaml && \
+    micromamba clean --all --yes
+
+%runscript
+    #!/bin/bash
+
+    # Activate base environment
+    source /usr/local/bin/_activate_current_env.sh

--- a/singularities/ascat-3.2.0/ascat-3.2.0.yaml
+++ b/singularities/ascat-3.2.0/ascat-3.2.0.yaml
@@ -1,0 +1,13 @@
+name: ascat-3.2.0
+channels:
+  - conda-forge
+  - bioconda
+dependencies:
+  - ascat=3.2.0
+  - cancerit-allelecount=4.3.0
+  - r-ggpubr
+  - r-cowplot
+  - r-tidyverse
+  - r-htmlwidgets
+  - r-plotly
+  - r-optparse

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -273,12 +273,16 @@ def wrapper(instrument=None, outpath=None):
                 end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, t_key, None)))
                 final_pairs.append(f'{t_key} (T), {t_value[2]} {["prio" if t_value[3] else ""][0]}')
 
-        for n_key in normal_samples:
+        for n_key, n_value in normal_samples.items():
             if not any(n_key == pair[1] for pair in paired_samples):
+                # We are no longer running the normal-only samples
+                """
                 outputdir = submit_pipeline(None, n_key, outpath, config, logger, threads)
                 outputdirs.append(outputdir)
                 end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, None, n_key)))
                 final_pairs.append(f'{n_key} (N), {n_value[2]} {["prio" if n_value[3] else ""][0]}')
+                """
+                logger.info(f'Skipping normal-only sample {n_key} as it is not paired with a tumor sample.')
 
         # Start several samples at the same time
         for t in threads:

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -278,6 +278,11 @@ def wrapper(instrument=None, outpath=None):
             if not any(n_key == pair[1] for pair in paired_samples):
                 logger.info(f'Skipping normal-only sample {n_key} as it is not paired with a tumor sample.')
 
+        # If there are no samples to process, skip the rest of the code
+        if not threads:
+            logger.info("No samples to process for this run. Skipping emails and further processing.")
+            break
+
         # Start several samples at the same time
         for t in threads:
             t.start()

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -273,15 +273,9 @@ def wrapper(instrument=None, outpath=None):
                 end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, t_key, None)))
                 final_pairs.append(f'{t_key} (T), {t_value[2]} {["prio" if t_value[3] else ""][0]}')
 
+        # We are currently not running the normal-only samples
         for n_key, n_value in normal_samples.items():
             if not any(n_key == pair[1] for pair in paired_samples):
-                # We are no longer running the normal-only samples
-                """
-                outputdir = submit_pipeline(None, n_key, outpath, config, logger, threads)
-                outputdirs.append(outputdir)
-                end_threads.append(threading.Thread(target=analysis_end, args=(outputdir, None, n_key)))
-                final_pairs.append(f'{n_key} (N), {n_value[2]} {["prio" if n_value[3] else ""][0]}')
-                """
                 logger.info(f'Skipping normal-only sample {n_key} as it is not paired with a tumor sample.')
 
         # Start several samples at the same time

--- a/workflows/rules/results_sharing/share_to_resultdir.smk
+++ b/workflows/rules/results_sharing/share_to_resultdir.smk
@@ -33,6 +33,7 @@ if tumorid:
                 expand("{stype}/reports/{sname}_baf.igv", sname=normalid, stype=sampleconfig[normalname]["stype"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                expand("{stype}/ascat/{sname}_ascat_plot.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
             output:
                 "reporting/shared_result_files.txt"
             run:
@@ -58,6 +59,7 @@ if tumorid:
                 expand("{stype}/reports/{sname}_baf.igv", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+                expand("{stype}/ascat/{sname}_ascat_plot.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
             output:
                 "reporting/shared_result_files.txt"
             run:

--- a/workflows/rules/results_sharing/share_to_resultdir.smk
+++ b/workflows/rules/results_sharing/share_to_resultdir.smk
@@ -34,6 +34,8 @@ if tumorid:
                 expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/ascat/{sname}_ascat_plot.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+                expand("{stype}/ascat/{sname}_ascat_copynumber_IGV.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+                expand("{stype}/ascat/{sname}_ascat_BAF_IGV.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
             output:
                 "reporting/shared_result_files.txt"
             run:
@@ -60,6 +62,8 @@ if tumorid:
                 expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"], ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
                 expand("{stype}/ascat/{sname}_ascat_plot.png", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+                expand("{stype}/ascat/{sname}_ascat_copynumber_IGV.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+                expand("{stype}/ascat/{sname}_ascat_BAF_IGV.seg", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
             output:
                 "reporting/shared_result_files.txt"
             run:

--- a/workflows/rules/variantcalling/ascat.smk
+++ b/workflows/rules/variantcalling/ascat.smk
@@ -28,6 +28,7 @@ if normalid:
             wgscov = lambda wildcards: get_cov_files(wildcards)["wgscov"],
             ycov = lambda wildcards: get_cov_files(wildcards)["ycov"]
         params:
+            # alleleCounter executable is in conda bin directory in the ascat container
             allelecounter_exe = pipeconfig["rules"]["ascat_run"]["allelecounter_exe"],
             alleles_prefix = pipeconfig["rules"]["ascat_run"]["alleles_prefix"],
             loci_prefix = pipeconfig["rules"]["ascat_run"]["loci_prefix"],

--- a/workflows/rules/variantcalling/ascat.smk
+++ b/workflows/rules/variantcalling/ascat.smk
@@ -141,5 +141,5 @@ rule ascat_plot:
             --Rdata-file {input.rdata_file} \
             --output-plot {output.plot} \
             --output-seg {output.seg} \
-            --output-BAF {output.BAF}
+            --output-baf {output.BAF}
         """

--- a/workflows/rules/variantcalling/ascat.smk
+++ b/workflows/rules/variantcalling/ascat.smk
@@ -1,0 +1,106 @@
+if normalid:
+    rule ascat_run:
+        input:
+            tumor_bam = expand("{stype}/realign/{sname}_REALIGNED.bam", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+            normal_bam = expand("{stype}/realign/{sname}_REALIGNED.bam", sname=normalid, stype=sampleconfig[normalname]["stype"]),
+        params:
+            allelecounter_exe = pipeconfig["rules"]["ascat_run"]["allelecounter_exe"],
+            alleles_prefix = pipeconfig["rules"]["ascat_run"]["alleles_prefix"],
+            loci_prefix = pipeconfig["rules"]["ascat_run"]["loci_prefix"],
+            gender = "XX",
+            genome_version = pipeconfig["rules"]["ascat_run"]["genome_version"],
+            gc_content_file = pipeconfig["rules"]["ascat_run"]["gc_content_file"],
+            replic_timing_file = pipeconfig["rules"]["ascat_run"]["replic_timing_file"],
+            ascat_run_script = f"{ROOT_DIR}/workflows/scripts/ascat_run.R",
+        output:
+            output_dir = temp(directory("{stype}/ascat/{sname}_run_output")),
+            rdata_file = temp("{stype}/ascat/{sname}_ascat_bc.Rdata"),
+            segments = temp("{stype}/ascat/{sname}.segments.txt"),
+        singularity:
+            pipeconfig["singularities"]["ascat"]["sing"]
+        threads:
+            clusterconf["ascat_run"]["threads"]
+        shell:
+            """
+            Rscript {params.ascat_run_script} \
+                --tumor-bam {input.tumor_bam} \
+                --tumor-name {wildcards.sname} \
+                --normal-bam {input.normal_bam} \
+                --normal-name {wildcards.sname}_normal \
+                --allelecounter-exe {params.allelecounter_exe} \
+                --alleles-prefix {params.alleles_prefix} \
+                --loci-prefix {params.loci_prefix} \
+                --gender {params.gender} \
+                --genome-version {params.genome_version} \
+                --nthreads {threads} \
+                --gc-content-file {params.gc_content_file} \
+                --replic-timing-file {params.replic_timing_file} \
+                --output-dir {output.output_dir} \
+                --tumoronly FALSE
+            mv {output.output_dir}/{wildcards.sname}_ascat_bc.Rdata {output.rdata_file}
+            mv {output.output_dir}/{wildcards.sname}.segments.txt {output.segments}
+            """
+
+else:
+    rule ascat_run:
+        input:
+            tumor_bam = expand("{stype}/realign/{sname}_REALIGNED.bam", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+        params:
+            allelecounter_exe = pipeconfig["rules"]["ascat_run"]["allelecounter_exe"],
+            alleles_prefix = pipeconfig["rules"]["ascat_run"]["alleles_prefix"],
+            loci_prefix = pipeconfig["rules"]["ascat_run"]["loci_prefix"],
+            gender = "XX",
+            genome_version = pipeconfig["rules"]["ascat_run"]["genome_version"],
+            gc_content_file = pipeconfig["rules"]["ascat_run"]["gc_content_file"],
+            replic_timing_file = pipeconfig["rules"]["ascat_run"]["replic_timing_file"],
+            ascat_run_script = f"{ROOT_DIR}/workflows/scripts/ascat_run.R",
+        output:
+            output_dir = temp(directory("{stype}/ascat/{sname}_run_output")),
+            rdata_file = temp("{stype}/ascat/{sname}_ascat_bc.Rdata"),
+            segments = temp("{stype}/ascat/{sname}.segments.txt"),
+        singularity:
+            pipeconfig["singularities"]["ascat"]["sing"]
+        threads:
+            clusterconf["ascat_run"]["threads"]
+        shell:
+            """
+            Rscript {params.ascat_run_script} \
+                --tumor-bam {input.tumor_bam} \
+                --tumor-name {wildcards.sname} \
+                --allelecounter-exe {params.allelecounter_exe} \
+                --alleles-prefix {params.alleles_prefix} \
+                --loci-prefix {params.loci_prefix} \
+                --gender {params.gender} \
+                --genome-version {params.genome_version} \
+                --nthreads {threads} \
+                --gc-content-file {params.gc_content_file} \
+                --replic-timing-file {params.replic_timing_file} \
+                --output-dir {output.output_dir} \
+                --tumoronly TRUE
+            mv {output.output_dir}/{wildcards.sname}_ascat_bc.Rdata {output.rdata_file}
+            mv {output.output_dir}/{wildcards.sname}.segments.txt {output.segments}
+            """
+
+rule ascat_plot:
+    input:
+        rdata_file = "{stype}/ascat/{sname}_ascat_bc.Rdata",
+        segments = "{stype}/ascat/{sname}.segments.txt",
+    params:
+        tumorname = tumorname,
+        gender = "XX",
+        genome_fai = pipeconfig["referencefai"],
+        ascat_plot_script = f"{ROOT_DIR}/workflows/scripts/ascat_custom_plot.R",
+    output:
+        plot = temp("{stype}/ascat/{sname}_ascat_plot.png")
+    singularity:
+        pipeconfig["singularities"]["ascat"]["sing"]
+    shell:
+        """
+        Rscript {params.ascat_plot_script} \
+            --tumorname {params.tumorname} \
+            --gender {params.gender} \
+            --genome-fai {params.genome_fai} \
+            --segments {input.segments} \
+            --Rdata-file {input.rdata_file} \
+            --output-plot {output.plot}
+        """

--- a/workflows/rules/variantcalling/ascat.smk
+++ b/workflows/rules/variantcalling/ascat.smk
@@ -1,13 +1,38 @@
+import os
+from workflows.scripts.sex import calc_sex
+
+# Helper function to resolve file paths dynamically
+def get_cov_files(wildcards):
+    if normalid:
+        return {
+            "wgscov": "{stype}/reports/{sname}_WGScov.tsv".format(
+                stype=sampleconfig[normalname]["stype"], sname=normalid),
+            "ycov": "{stype}/reports/{sname}_Ycov.tsv".format(
+                stype=sampleconfig[normalname]["stype"], sname=normalid)
+        }
+    else:
+        return {
+            "wgscov": "{stype}/reports/{sname}_WGScov.tsv".format(
+                stype=sampleconfig[tumorname]["stype"], sname=tumorid),
+            "ycov": "{stype}/reports/{sname}_Ycov.tsv".format(
+                stype=sampleconfig[tumorname]["stype"], sname=tumorid)
+        }
+
 if normalid:
     rule ascat_run:
         input:
             tumor_bam = expand("{stype}/realign/{sname}_REALIGNED.bam", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
             normal_bam = expand("{stype}/realign/{sname}_REALIGNED.bam", sname=normalid, stype=sampleconfig[normalname]["stype"]),
+            wgscov = lambda wildcards: get_cov_files(wildcards)["wgscov"],
+            ycov = lambda wildcards: get_cov_files(wildcards)["ycov"]
         params:
             allelecounter_exe = pipeconfig["rules"]["ascat_run"]["allelecounter_exe"],
             alleles_prefix = pipeconfig["rules"]["ascat_run"]["alleles_prefix"],
             loci_prefix = pipeconfig["rules"]["ascat_run"]["loci_prefix"],
-            gender = "XX",
+            gender = lambda wildcards: calc_sex(
+                get_cov_files(wildcards)["wgscov"],
+                get_cov_files(wildcards)["ycov"]
+            ),            
             genome_version = pipeconfig["rules"]["ascat_run"]["genome_version"],
             gc_content_file = pipeconfig["rules"]["ascat_run"]["gc_content_file"],
             replic_timing_file = pipeconfig["rules"]["ascat_run"]["replic_timing_file"],
@@ -45,11 +70,16 @@ else:
     rule ascat_run:
         input:
             tumor_bam = expand("{stype}/realign/{sname}_REALIGNED.bam", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+            wgscov = lambda wildcards: get_cov_files(wildcards)["wgscov"],
+            ycov = lambda wildcards: get_cov_files(wildcards)["ycov"]
         params:
             allelecounter_exe = pipeconfig["rules"]["ascat_run"]["allelecounter_exe"],
             alleles_prefix = pipeconfig["rules"]["ascat_run"]["alleles_prefix"],
             loci_prefix = pipeconfig["rules"]["ascat_run"]["loci_prefix"],
-            gender = "XX",
+            gender = lambda wildcards: calc_sex(
+                get_cov_files(wildcards)["wgscov"],
+                get_cov_files(wildcards)["ycov"]
+            ),            
             genome_version = pipeconfig["rules"]["ascat_run"]["genome_version"],
             gc_content_file = pipeconfig["rules"]["ascat_run"]["gc_content_file"],
             replic_timing_file = pipeconfig["rules"]["ascat_run"]["replic_timing_file"],
@@ -85,13 +115,20 @@ rule ascat_plot:
     input:
         rdata_file = "{stype}/ascat/{sname}_ascat_bc.Rdata",
         segments = "{stype}/ascat/{sname}.segments.txt",
+        wgscov = lambda wildcards: get_cov_files(wildcards)["wgscov"],
+        ycov = lambda wildcards: get_cov_files(wildcards)["ycov"]
     params:
         tumorname = tumorname,
-        gender = "XX",
+        gender = lambda wildcards: calc_sex(
+                get_cov_files(wildcards)["wgscov"],
+                get_cov_files(wildcards)["ycov"]
+        ),        
         genome_fai = pipeconfig["referencefai"],
         ascat_plot_script = f"{ROOT_DIR}/workflows/scripts/ascat_custom_plot.R",
     output:
-        plot = temp("{stype}/ascat/{sname}_ascat_plot.png")
+        plot = temp("{stype}/ascat/{sname}_ascat_plot.png"),
+        seg = temp("{stype}/ascat/{sname}_ascat_copynumber_IGV.seg"),
+        BAF = temp("{stype}/ascat/{sname}_ascat_BAF_IGV.seg")
     singularity:
         pipeconfig["singularities"]["ascat"]["sing"]
     shell:
@@ -102,5 +139,7 @@ rule ascat_plot:
             --genome-fai {params.genome_fai} \
             --segments {input.segments} \
             --Rdata-file {input.rdata_file} \
-            --output-plot {output.plot}
+            --output-plot {output.plot} \
+            --output-seg {output.seg} \
+            --output-BAF {output.BAF}
         """

--- a/workflows/rules/variantcalling/ascat.smk
+++ b/workflows/rules/variantcalling/ascat.smk
@@ -43,7 +43,8 @@ if normalid:
             replic_timing_file = pipeconfig["rules"]["ascat_run"]["replic_timing_file"],
             ascat_run_script = f"{ROOT_DIR}/workflows/scripts/ascat_run.R",
         output:
-            # All output will be stored in the temporary output_directory except the Rdata and segments files
+            # All output will be stored in the temporary output_directory. 
+            # The Rdata and segments files are moved to the below output locations for further processing.
             output_dir = temp(directory("{stype}/ascat/{sname}_run_output")),
             rdata_file = temp("{stype}/ascat/{sname}_ascat_bc.Rdata"),
             segments = temp("{stype}/ascat/{sname}.segments.txt"),

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -59,7 +59,7 @@ else:
         shell:
             """
             set -e
-            (python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_bam} {input.normal_bam} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config} {input.wgscovfile} {input.ycov} &&
+            (python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_bam} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config} {input.wgscovfile} {input.ycov} &&
             freec -conf {output.config}) || (touch {output.config} {output.tumor_ratio} {output.info})
             """
 

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -59,7 +59,7 @@ else:
             """
             set -e
             (python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_bam} {input.normal_bam} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config} {input.wgscovfile} {input.ycov} &&
-            freec -conf {output.config}) || (touch {output.config} {output.tumor_ratio} {output.info} {output.tumor_ratio}.failed)
+            freec -conf {output.config}) || (touch {output.config} {output.tumor_ratio} {output.info})
             """
 
 rule control_freec_plot:
@@ -77,12 +77,5 @@ rule control_freec_plot:
         ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg"),
     shell:
         """
-        FAILED_FILE=$(realpath {input.ratio}.failed)
-        echo "Checking for failed file: $FAILED_FILE"
-        if test -f $FAILED_FILE; then
-            echo "Skipping plot for {wildcards.sname} because Control-FREEC failed."
-            touch {output.ratio_plot} {output.ratio_seg}
-        else
-            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg}
-        fi
+        Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg}
         """

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -25,10 +25,11 @@ if normalid:
         shadow:
             pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
         shell:
+            # The output files are created by freec, but we also create them if freec fails
             """
             set -e
             (python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_bam} {input.normal_bam} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config} {input.wgscovfile} {input.ycov} &&
-            freec -conf {output.config}) || (touch {output.config} {output.tumor_ratio} {output.info} {output.tumor_ratio}.failed)
+            freec -conf {output.config}) || (touch {output.config} {output.tumor_ratio} {output.info})
             """
 
 else:
@@ -76,6 +77,7 @@ rule control_freec_plot:
         ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png"),
         ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg"),
     shell:
+        # The Rscript accepts empty input files, so we can run it even if the previous step failed
         """
         Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg}
         """

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -83,6 +83,6 @@ rule control_freec_plot:
             echo "Skipping plot for {wildcards.sname} because Control-FREEC failed."
             touch {output.ratio_plot} {output.ratio_seg}
         else
-            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg}
+            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg}
         fi
         """

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -2,7 +2,11 @@ if normalid:
     rule control_freec_run:
         input:
             tumor_bam = expand("{stype}/realign/{sname}_REALIGNED.bam", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+            tumor_bai = expand("{stype}/realign/{sname}_REALIGNED.bam.bai", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
             normal_bam = expand("{stype}/realign/{sname}_REALIGNED.bam", sname=normalid, stype=sampleconfig[normalname]["stype"]),
+            normal_bai = expand("{stype}/realign/{sname}_REALIGNED.bam.bai", sname=normalid, stype=sampleconfig[normalname]["stype"]),
+            wgscovfile = expand("{stype}/reports/{sname}_WGScov.tsv", stype=sampleconfig[normalname]["stype"], sname=normalid),
+            ycov = expand("{stype}/reports/{sname}_Ycov.tsv", stype=sampleconfig[normalname]["stype"], sname=normalid),
         params:
             config_template = pipeconfig["rules"]["control-freec"].get("config_template", f"{ROOT_DIR}/workflows/scripts/control_freec_config.txt"),
             edit_config = pipeconfig["rules"]["control-freec"].get("edit_config", f"{ROOT_DIR}/workflows/scripts/control_freec_edit_config.py"),
@@ -22,14 +26,18 @@ if normalid:
             pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
         shell:
             """
-            python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_bam} {input.normal_bam} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config}
-            freec -conf {output.config}
+            set -e
+            (python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_bam} {input.normal_bam} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config} {input.wgscovfile} {input.ycov} &&
+            freec -conf {output.config}) || (touch {output.config} {output.tumor_ratio} {output.info} {output.tumor_ratio}.failed)
             """
 
 else:
     rule control_freec_run:
         input:
             tumor_bam = expand("{stype}/realign/{sname}_REALIGNED.bam", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+            tumor_bai = expand("{stype}/realign/{sname}_REALIGNED.bam.bai", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
+            wgscovfile = expand("{stype}/reports/{sname}_WGScov.tsv", stype=sampleconfig[tumorname]["stype"], sname=tumorid),  # For tumor only, ycov and wgscov are from tumor
+            ycov = expand("{stype}/reports/{sname}_Ycov.tsv", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
         params:
             config_template = pipeconfig["rules"]["control-freec"].get("config_template", f"{ROOT_DIR}/workflows/scripts/control_freec_config.txt"),
             edit_config = pipeconfig["rules"]["control-freec"].get("edit_config", f"{ROOT_DIR}/workflows/scripts/control_freec_edit_config.py"),
@@ -49,8 +57,9 @@ else:
             pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
         shell:
             """
-            python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_bam} {params.normal_bam} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config}
-            freec -conf {output.config}
+            set -e
+            (python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_bam} {input.normal_bam} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config} {input.wgscovfile} {input.ycov} &&
+            freec -conf {output.config}) || (touch {output.config} {output.tumor_ratio} {output.info} {output.tumor_ratio}.failed)
             """
 
 rule control_freec_plot:
@@ -66,9 +75,14 @@ rule control_freec_plot:
     output:
         ratio_plot = temp("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.png"),
         ratio_seg = temp("{stype}/control-freec_{ploidy}/{sname}_controlfreec_ploidy{ploidy}.seg"),
-    shadow:
-        pipeconfig["rules"].get("control-freec", {}).get("shadow", pipeconfig.get("shadow", False))
     shell:
         """
-        Rscript {params.plot_script} {wildcards.sname} {input.ratio} {input.BAF} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg}
+        FAILED_FILE=$(realpath {input.ratio}.failed)
+        echo "Checking for failed file: $FAILED_FILE"
+        if test -f $FAILED_FILE; then
+            echo "Skipping plot for {wildcards.sname} because Control-FREEC failed."
+            touch {output.ratio_plot} {output.ratio_seg}
+        else
+            Rscript {params.plot_script} {wildcards.sname} {input.ratio} {params.fai} {params.cytoBandIdeo} {output.ratio_plot} {output.ratio_seg}
+        fi
         """

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -59,7 +59,7 @@ else:
         shell:
             """
             set -e
-            (python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_bam} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config} {input.wgscovfile} {input.ycov} &&
+            (python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_bam} {params.normal_bam} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config} {input.wgscovfile} {input.ycov} &&
             freec -conf {output.config}) || (touch {output.config} {output.tumor_ratio} {output.info})
             """
 

--- a/workflows/rules/variantcalling/control-freec.smk
+++ b/workflows/rules/variantcalling/control-freec.smk
@@ -29,7 +29,7 @@ if normalid:
             """
             set -e
             (python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_bam} {input.normal_bam} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config} {input.wgscovfile} {input.ycov} &&
-            freec -conf {output.config}) || (touch {output.config} {output.tumor_ratio} {output.info})
+            freec -conf {output.config}) || (touch {output.config} {output.tumor_ratio} {output.info}; echo "[control-freec] WARNING: FREEC failed with ploidy {wildcards.ploidy}, creating empty outputs and continuing." >&2)
             """
 
 else:
@@ -60,7 +60,7 @@ else:
             """
             set -e
             (python {params.edit_config} {params.config_template} {wildcards.ploidy} {input.tumor_bam} {params.normal_bam} {params.chrLenFile} {params.chrFiles} {params.mappability} {threads} {output.config} {input.wgscovfile} {input.ycov} &&
-            freec -conf {output.config}) || (touch {output.config} {output.tumor_ratio} {output.info})
+            freec -conf {output.config}) || (touch {output.config} {output.tumor_ratio} {output.info}; echo "[control-freec] WARNING: FREEC failed with ploidy {wildcards.ploidy}, creating empty outputs and continuing." >&2)
             """
 
 rule control_freec_plot:

--- a/workflows/scripts/annotate_manta/manta_summary.py
+++ b/workflows/scripts/annotate_manta/manta_summary.py
@@ -13,34 +13,6 @@ def manta_summary(mantaSV_vcf, mantaSV_summary, tumorname, genelist, normalname=
     df = df.dropna(subset=['ID'])
 
 
-    # this part of the script removes duplicates (translocations from both directions)
-
-    row_indices = []
-
-    for a in df['ID']:
-        for b in df['MATEID']:
-            if a == b:
-
-                row_index_b = df[df['MATEID']==b].index.values
-                row_index_a = df[df['ID']==a].index.values
-
-
-                # append indices as tuples for each matching pair
-                row_indices.append((row_index_a[0], row_index_b[0]))
-
-
-
-    # get pair only once (a,b) and remove the same pair (b,a)
-    a_b_pairs = [tup for tup in row_indices if tup[0] < tup[1]]
-
-
-
-    # second element of each tuple = row indices to be removed
-    remove_indices = [i[1] for i in a_b_pairs]
-
-
-    df.drop(remove_indices, 0, inplace=True)
-
     # this part of the script highlights genes from the gene list
 
     # open the genelist

--- a/workflows/scripts/ascat_custom_plot.R
+++ b/workflows/scripts/ascat_custom_plot.R
@@ -23,6 +23,7 @@ opt_parser <- OptionParser(option_list = option_list)
 opt <- parse_args(opt_parser)
 
 # Map "male" and "female" to "XY" and "XX"
+# Added for compatibility with the calc_sex() function
 if (opt$gender == "male") {
   opt$gender <- "XY"
 } else if (opt$gender == "female") {
@@ -31,7 +32,7 @@ if (opt$gender == "male") {
 
 theme_set(theme_pubclean())
 
-
+# The fai is used to get the chromosome lengths and plot them sequentially
 fai <- read.table(opt$`genome-fai`, header = FALSE, sep = "\t", 
                   col.names = c("chr", "length", "start", "value1", "value2")) %>%
   mutate(chr = substr(chr,4,30))%>%
@@ -65,6 +66,7 @@ if (any(seg_df$ascat_ploidy > max_ploidy)) {
       ascat_ploidy - (round(ascat_ploidy - max_ploidy, 0)),
       ascat_ploidy
     ))
+  # If the ploidy is capped, make it clear in the plot with the labels
   breaks <- seq(0, max_ploidy, by = 1)
   labels <- c(as.character(breaks[-length(breaks)]), paste0(">", max_ploidy))
 } else {

--- a/workflows/scripts/ascat_custom_plot.R
+++ b/workflows/scripts/ascat_custom_plot.R
@@ -1,0 +1,139 @@
+library(data.table)
+library(ggpubr)
+library(cowplot)
+library(tidyverse)
+library(plotly)
+library(htmlwidgets)
+library(optparse)
+
+# Define command-line arguments
+option_list <- list(
+  make_option("--tumorname", type = "character", help = "Tumor sample name", metavar = "character"),
+  make_option("--gender", type = "character", help = "Gender of the sample (e.g., XX or XY)", metavar = "character"),
+  make_option("--genome-fai", type = "character", help = "Path to the genome FAI file", metavar = "character"),
+  make_option("--segments", type = "character", help = "Path to the segments file", metavar = "character"),
+  make_option("--Rdata-file", type = "character", help = "Path to the ascat run Rdata file", metavar = "character"),
+  make_option("--output-plot", type = "character", help = "Path to output plot", metavar = "character")
+)
+
+# Parse command-line arguments
+opt_parser <- OptionParser(option_list = option_list)
+opt <- parse_args(opt_parser)
+
+
+theme_set(theme_pubclean())
+
+
+fai <- read.table(opt$`genome-fai`, header = FALSE, sep = "\t", 
+                  col.names = c("chr", "length", "start", "value1", "value2")) %>%
+  mutate(chr = substr(chr,4,30))%>%
+  mutate(middle = start + (length / 2))
+if (opt$`gender` == "XY") {
+  fai <- fai[1:24,]
+} else {
+  fai <- fai[1:23,]
+  }
+
+## Segments
+# Read the segments table
+seg_df <- read.table(opt$`segments`, header = TRUE, sep = "\t")
+# Merge with fai to adjust positions
+seg_df <- merge(seg_df, fai, by = "chr") %>%
+  mutate(
+    startpos = startpos + start,
+    endpos = endpos + start,
+    segment_size = endpos - startpos,
+    segment_frac = segment_size / sum(segment_size)
+  )%>%
+  dplyr::rename(minor_allele = nMinor, major_allele = nMajor)%>%
+  pivot_longer(cols = c(major_allele, minor_allele), names_to = "allele", values_to = "ascat_ploidy")
+
+## Load ascat.bc from the Rdata file
+load(opt$`Rdata-file`)  # Load the Rdata file containing ascat.bc
+
+## BAF
+# Extract BAF from the ascat.bc object
+setDT(ascat.bc$Tumor_BAF, keep.rownames = TRUE)[]%>%
+  separate_wider_delim(rn, "_", names = c("chr","pos"))%>%
+  mutate(pos = as.numeric(pos))%>%
+  dplyr::select(1,2,"BAF"= 3)->tumorBAF_df
+# Merge with fai to adjust positions
+tumorBAF_df_adj <- merge(tumorBAF_df, fai, by = "chr") %>%
+  mutate(
+    pos = pos + start
+  )
+
+## LogR
+# Extract LogR from the ascat.bc object
+setDT(ascat.bc$Tumor_LogR, keep.rownames = T)[]%>%
+  separate_wider_delim(rn, "_", names = c("chr","pos"))%>%
+  mutate(pos = as.numeric(pos))%>%
+  dplyr::select(1,2,"LogR"= 3)->tumorLogR_df
+# Merge with fai to adjust positions
+tumorLogR_df_adj <- merge(tumorLogR_df, fai, by = "chr") %>%
+  mutate(
+    pos = pos + start
+  )
+
+## Plot segments, BAF, and LogR
+png(opt$`output-plot`, width = 24, height = 24, units = "cm", res = 1200)
+
+Segment_plot <- ggplot(fai)+
+  geom_vline(aes(xintercept = start), col = "grey")+
+  geom_linerange(data = seg_df, 
+                 aes(xmin = startpos, xmax = endpos, y = ascat_ploidy, col = allele), 
+                 linewidth = 2.5, position = position_dodge(width = -0.1))+
+  geom_text(aes(label = chr, x = middle, y = Inf), vjust = 1, size = 3.5)+
+  ylab("Copy number")+
+  theme(legend.title=element_blank(), axis.title.x = element_blank())
+
+BAF_plot <-  ggplot(fai)+
+  geom_vline(aes(xintercept = start), col = "grey")+
+  geom_point(data = tumorBAF_df_adj, aes(pos, BAF), shape = '.', col = "#00000010")+
+  geom_text(aes(label = chr, x = middle, y = Inf), vjust = 1, size = 3.5)+
+  scale_y_continuous(breaks = c(0.1,0.3,0.5,0.7,0.9), 
+                     limits = c(0.05,0.95)) +
+  theme(axis.title.x = element_blank())
+
+LogR_plot <-  ggplot(fai)+
+  geom_vline(aes(xintercept = start), col = "grey")+
+  geom_point(data = tumorLogR_df_adj, aes(pos, LogR), shape = '.', col = "#00000010")+
+  geom_text(aes(label = chr, x = middle, y = Inf), vjust = 1, size = 3.5)+
+  scale_y_continuous(limits = c(-2,2))+
+  theme(axis.title.x = element_blank())
+
+plot_grid(Segment_plot, BAF_plot, LogR_plot, 
+          ncol = 1, align = "v", rel_heights = c(3,2,2))
+
+dev.off()
+
+# Write the segmentation data to a file for IGV visualization
+output_ratio_seg <- file.path(dirname(opt$`output-plot`), paste0(basename(opt$`output-plot`), "_ascat_copynumber_IGV.seg"))
+
+# Add IGV-compatible header
+writeLines("#track graphType=points maxHeightPixels=300:300:300 color=0,0,0 altColor=0,0,0", con = output_ratio_seg)
+
+# Process the segments file to output nMajor and nMinor as separate rows
+read.table(opt$`segments`, header = TRUE, sep = "\t") %>%
+  dplyr::rename(Sample = sample, Chromosome = chr, Start = startpos, End = endpos) %>%
+  mutate(
+    Chromosome = paste0("chr", Chromosome),
+    Copynumber = nMajor + nMinor,
+  ) %>%  # Add "chr" prefix for IGV compatibility
+  dplyr::select(Sample, Chromosome, Start, End, Copynumber) %>%
+  write.table(file = output_ratio_seg, sep = "\t", quote = FALSE, row.names = FALSE, col.names = TRUE, append = TRUE)
+
+
+# Write the BAF data to an IGV-compatible file
+output_baf_seg <- file.path(dirname(opt$`output-plot`), paste0(basename(opt$`output-plot`), "_ascat_BAF_IGV.seg"))
+
+# Add IGV-compatible header
+writeLines("#track graphType=points maxHeightPixels=100:100:100 color=0,0,255 altColor=255,0,0", con = output_baf_seg)
+
+# Process the BAF data for IGV visualization
+tumorBAF_df %>%
+  dplyr::rename(Chromosome = chr, Start = pos) %>%
+  mutate(Chromosome = paste0("chr", Chromosome), End = Start, Sample = opt$`tumorname`) %>%  # Add "chr" prefix for IGV compatibility
+  dplyr::select(Sample, Chromosome, Start, End, BAF) %>%
+  write.table(file = output_baf_seg, sep = "\t", quote = FALSE, row.names = FALSE, col.names = TRUE, append = TRUE)
+

--- a/workflows/scripts/ascat_custom_plot.R
+++ b/workflows/scripts/ascat_custom_plot.R
@@ -13,13 +13,21 @@ option_list <- list(
   make_option("--genome-fai", type = "character", help = "Path to the genome FAI file", metavar = "character"),
   make_option("--segments", type = "character", help = "Path to the segments file", metavar = "character"),
   make_option("--Rdata-file", type = "character", help = "Path to the ascat run Rdata file", metavar = "character"),
-  make_option("--output-plot", type = "character", help = "Path to output plot", metavar = "character")
+  make_option("--output-plot", type = "character", help = "Path to output plot", metavar = "character"),
+  make_option("--output-seg", type = "character", help = "Path to output segments file", metavar = "character"),
+  make_option("--output-baf", type = "character", help = "Path to output BAF file", metavar = "character")
 )
 
 # Parse command-line arguments
 opt_parser <- OptionParser(option_list = option_list)
 opt <- parse_args(opt_parser)
 
+# Map "male" and "female" to "XY" and "XX"
+if (opt$gender == "male") {
+  opt$gender <- "XY"
+} else if (opt$gender == "female") {
+  opt$gender <- "XX"
+}
 
 theme_set(theme_pubclean())
 
@@ -108,7 +116,10 @@ plot_grid(Segment_plot, BAF_plot, LogR_plot,
 dev.off()
 
 # Write the segmentation data to a file for IGV visualization
-output_ratio_seg <- file.path(dirname(opt$`output-plot`), paste0(basename(opt$`output-plot`), "_ascat_copynumber_IGV.seg"))
+output_ratio_seg <- opt$`output-seg`
+if (is.null(output_ratio_seg)) {
+  output_ratio_seg <- file.path(dirname(opt$`output-plot`), paste0(basename(opt$`output-plot`), "_ascat_copynumber_IGV.seg"))
+}
 
 # Add IGV-compatible header
 writeLines("#track graphType=points maxHeightPixels=300:300:300 color=0,0,0 altColor=0,0,0", con = output_ratio_seg)
@@ -125,7 +136,10 @@ read.table(opt$`segments`, header = TRUE, sep = "\t") %>%
 
 
 # Write the BAF data to an IGV-compatible file
-output_baf_seg <- file.path(dirname(opt$`output-plot`), paste0(basename(opt$`output-plot`), "_ascat_BAF_IGV.seg"))
+output_baf_seg <- opt$`output-baf`
+if (is.null(output_baf_seg)) {
+  output_baf_seg <- file.path(dirname(opt$`output-plot`), paste0(basename(opt$`output-plot`), "_ascat_BAF_IGV.seg"))
+}
 
 # Add IGV-compatible header
 writeLines("#track graphType=points maxHeightPixels=100:100:100 color=0,0,255 altColor=255,0,0", con = output_baf_seg)

--- a/workflows/scripts/ascat_run.R
+++ b/workflows/scripts/ascat_run.R
@@ -25,7 +25,6 @@ opt <- parse_args(opt_parser)
 
 # Convert input file paths to absolute paths
 opt$`tumor-bam` <- normalizePath(opt$`tumor-bam`)
-opt$`normal-bam` <- normalizePath(opt$`normal-bam`)
 opt$`alleles-prefix` <- normalizePath(opt$`alleles-prefix`)
 opt$`loci-prefix` <- normalizePath(opt$`loci-prefix`)
 opt$`gc-content-file` <- normalizePath(opt$`gc-content-file`)
@@ -71,6 +70,8 @@ if (opt$tumoronly) {
   )
 
 } else {
+  opt$`normal-bam` <- normalizePath(opt$`normal-bam`)
+
   # Tumor-and-normal analysis
   ascat.prepareHTS(
     tumourseqfile = opt$`tumor-bam`,

--- a/workflows/scripts/ascat_run.R
+++ b/workflows/scripts/ascat_run.R
@@ -101,9 +101,6 @@ if (opt$tumoronly) {
 
 }
 
-# Restore the original working directory
-setwd(original_wd)
-
 # Common steps for both tumor-only and tumor-and-normal
 ascat.bc <- ascat.correctLogR(
   ascat.bc,
@@ -116,6 +113,9 @@ if (opt$tumoronly) {
 } else {
   ascat.bc <- ascat.aspcf(ascat.bc)
 }
+
+# Restore the original working directory
+setwd(original_wd)
 
 ascat.output <- ascat.runAscat(ascat.bc, gamma = 1, write_segments = TRUE, img.dir = opt$`output-dir`)
 

--- a/workflows/scripts/ascat_run.R
+++ b/workflows/scripts/ascat_run.R
@@ -25,12 +25,12 @@ opt <- parse_args(opt_parser)
 
 # Convert input file paths to absolute paths
 opt$`tumor-bam` <- normalizePath(opt$`tumor-bam`)
-opt$`alleles-prefix` <- normalizePath(opt$`alleles-prefix`)
-opt$`loci-prefix` <- normalizePath(opt$`loci-prefix`)
+opt$`alleles-prefix` <- normalizePath(opt$`alleles-prefix`, mustWork = FALSE)
+opt$`loci-prefix` <- normalizePath(opt$`loci-prefix`, mustWork = FALSE)
 opt$`gc-content-file` <- normalizePath(opt$`gc-content-file`)
 opt$`replic-timing-file` <- normalizePath(opt$`replic-timing-file`)
 if (!opt$tumoronly) {
-  opt$`normal-bam` <- normalizePath(opt$`normal-bam`)
+    opt$`normal-bam` <- normalizePath(opt$`normal-bam`)
 }
 
 # Map "male" and "female" to "XY" and "XX"

--- a/workflows/scripts/ascat_run.R
+++ b/workflows/scripts/ascat_run.R
@@ -29,6 +29,9 @@ opt$`alleles-prefix` <- normalizePath(opt$`alleles-prefix`)
 opt$`loci-prefix` <- normalizePath(opt$`loci-prefix`)
 opt$`gc-content-file` <- normalizePath(opt$`gc-content-file`)
 opt$`replic-timing-file` <- normalizePath(opt$`replic-timing-file`)
+if (!opt$tumoronly) {
+  opt$`normal-bam` <- normalizePath(opt$`normal-bam`)
+}
 
 # Map "male" and "female" to "XY" and "XX"
 if (opt$gender == "male") {
@@ -70,8 +73,6 @@ if (opt$tumoronly) {
   )
 
 } else {
-  opt$`normal-bam` <- normalizePath(opt$`normal-bam`)
-
   # Tumor-and-normal analysis
   ascat.prepareHTS(
     tumourseqfile = opt$`tumor-bam`,

--- a/workflows/scripts/ascat_run.R
+++ b/workflows/scripts/ascat_run.R
@@ -31,6 +31,13 @@ opt$`loci-prefix` <- normalizePath(opt$`loci-prefix`)
 opt$`gc-content-file` <- normalizePath(opt$`gc-content-file`)
 opt$`replic-timing-file` <- normalizePath(opt$`replic-timing-file`)
 
+# Map "male" and "female" to "XY" and "XX"
+if (opt$gender == "male") {
+  opt$gender <- "XY"
+} else if (opt$gender == "female") {
+  opt$gender <- "XX"
+}
+
 # Ensure the output directory exists
 if (!dir.exists(opt$`output-dir`)) {
   dir.create(opt$`output-dir`, recursive = TRUE)

--- a/workflows/scripts/ascat_run.R
+++ b/workflows/scripts/ascat_run.R
@@ -1,0 +1,118 @@
+library(ASCAT)
+library(optparse)
+
+# Define command-line arguments
+option_list <- list(
+  make_option("--tumor-bam", type = "character", help = "Path to the tumor BAM file", metavar = "character"),
+  make_option("--tumor-name", type = "character", help = "Name of the tumor sample", metavar = "character"),
+  make_option("--normal-bam", type = "character", help = "Path to the normal BAM file (optional)", metavar = "character"),
+  make_option("--normal-name", type = "character", help = "Name of the normal sample (optional)", metavar = "character"),
+  make_option("--allelecounter-exe", type = "character", help = "Path to the allelecounter executable", metavar = "character"),
+  make_option("--alleles-prefix", type = "character", help = "Prefix for alleles file", metavar = "character"),
+  make_option("--loci-prefix", type = "character", help = "Prefix for loci file", metavar = "character"),
+  make_option("--gender", type = "character", help = "Gender of the sample (e.g., XX or XY)", metavar = "character"),
+  make_option("--genome-version", type = "character", help = "Genome version (e.g., hg38 or hg19)", metavar = "character"),
+  make_option("--nthreads", type = "integer", help = "Number of threads to use", metavar = "integer"),
+  make_option("--gc-content-file", type = "character", help = "Path to GC content file", metavar = "character"),
+  make_option("--replic-timing-file", type = "character", help = "Path to replication timing file", metavar = "character"),
+  make_option("--output-dir", type = "character", help = "Directory for output images and files", metavar = "character"),
+  make_option("--tumoronly", type = "logical", default = TRUE, help = "Set to TRUE for tumor-only analysis, FALSE for tumor-and-normal analysis", metavar = "logical")
+)
+
+# Parse command-line arguments
+opt_parser <- OptionParser(option_list = option_list)
+opt <- parse_args(opt_parser)
+
+# Convert input file paths to absolute paths
+opt$`tumor-bam` <- normalizePath(opt$`tumor-bam`)
+opt$`normal-bam` <- normalizePath(opt$`normal-bam`)
+opt$`alleles-prefix` <- normalizePath(opt$`alleles-prefix`)
+opt$`loci-prefix` <- normalizePath(opt$`loci-prefix`)
+opt$`gc-content-file` <- normalizePath(opt$`gc-content-file`)
+opt$`replic-timing-file` <- normalizePath(opt$`replic-timing-file`)
+
+# Ensure the output directory exists
+if (!dir.exists(opt$`output-dir`)) {
+  dir.create(opt$`output-dir`, recursive = TRUE)
+}
+
+# Temporarily change the working directory to the output directory
+original_wd <- getwd()
+setwd(opt$`output-dir`)
+
+# Prepare ASCAT input
+if (opt$tumoronly) {
+  # Tumor-only analysis
+  ascat.prepareHTS(
+    tumourseqfile = opt$`tumor-bam`,
+    tumourname = opt$`tumor-name`,
+    allelecounter_exe = opt$`allelecounter-exe`,
+    alleles.prefix = opt$`alleles-prefix`,
+    loci.prefix = opt$`loci-prefix`,
+    gender = opt$gender,
+    genomeVersion = opt$`genome-version`,
+    nthreads = opt$nthreads,
+    tumourLogR_file = "tumor_logr.txt",
+    tumourBAF_file = "tumor_baf.txt"
+  )
+
+  ascat.bc <- ascat.loadData(
+    Tumor_LogR_file = "tumor_logr.txt",
+    Tumor_BAF_file = "tumor_baf.txt",
+    gender = opt$gender,
+    genomeVersion = opt$`genome-version`
+  )
+
+} else {
+  # Tumor-and-normal analysis
+  ascat.prepareHTS(
+    tumourseqfile = opt$`tumor-bam`,
+    normalseqfile = opt$`normal-bam`,
+    tumourname = opt$`tumor-name`,  
+    normalname = opt$`normal-name`,
+    allelecounter_exe = opt$`allelecounter-exe`,
+    alleles.prefix = opt$`alleles-prefix`,
+    loci.prefix = opt$`loci-prefix`,
+    gender = opt$gender,
+    genomeVersion = opt$`genome-version`,
+    nthreads = opt$nthreads,
+    tumourLogR_file = "tumor_logr.txt",
+    tumourBAF_file = "tumor_baf.txt",
+    normalLogR_file = "normal_logr.txt",
+    normalBAF_file = "normal_baf.txt"
+  )
+
+  ascat.bc <- ascat.loadData(
+    Tumor_LogR_file = "tumor_logr.txt",
+    Tumor_BAF_file = "tumor_baf.txt",
+    Germline_LogR_file = "normal_logr.txt",
+    Germline_BAF_file = "normal_baf.txt",
+    gender = opt$gender,
+    genomeVersion = opt$`genome-version`
+  )
+
+}
+
+# Restore the original working directory
+setwd(original_wd)
+
+# Common steps for both tumor-only and tumor-and-normal
+ascat.bc <- ascat.correctLogR(
+  ascat.bc,
+  GCcontentfile = opt$`gc-content-file`,
+  replictimingfile = opt$`replic-timing-file`
+)
+if (opt$tumoronly) {
+  gg <- ascat.predictGermlineGenotypes(ascat.bc, platform = "WGS_hg38_50X")
+  ascat.bc <- ascat.aspcf(ascat.bc, ascat.gg = gg)
+} else {
+  ascat.bc <- ascat.aspcf(ascat.bc)
+}
+
+ascat.output <- ascat.runAscat(ascat.bc, gamma = 1, write_segments = TRUE, img.dir = opt$`output-dir`)
+
+stats <- ascat.metrics(ascat.bc, ascat.output)
+stats_output_file <- file.path(opt$`output-dir`, paste0(opt$`tumor-name`, "_ascat_stats.tsv"))
+write.table(t(stats), stats_output_file, sep = "\t", quote = FALSE, row.names = TRUE, col.names = FALSE)
+
+save(ascat.bc, ascat.output, stats, file = file.path(opt$`output-dir`, paste0(opt$`tumor-name`, "_ascat_bc.Rdata")))

--- a/workflows/scripts/control_freec_config.txt
+++ b/workflows/scripts/control_freec_config.txt
@@ -32,7 +32,7 @@ contaminationAdjustment = TRUE
 
 #breakPointType = 4
 #forceGCcontentNormalization = 0
-sex = XY
+sex = XX
 
 
 ##set BedGraphOutput=TRUE if you want to create a BedGraph track for visualization in the UCSC genome browser:

--- a/workflows/scripts/control_freec_config.txt
+++ b/workflows/scripts/control_freec_config.txt
@@ -10,6 +10,7 @@ gemMappabilityFile = /clinical/exec/wgs_somatic/dependencies/control_freec/out10
 ploidy = 1,2,3,4
 outputDir = ./
 maxThreads = 4
+sex = XX
 
 
 ##Parameter "breakPointThreshold" specifies the maximal slope of the slope of residual sum of squares. The closer it is to Zero, the more breakpoints will be called.
@@ -32,7 +33,6 @@ contaminationAdjustment = TRUE
 
 #breakPointType = 4
 #forceGCcontentNormalization = 0
-sex = XX
 
 
 ##set BedGraphOutput=TRUE if you want to create a BedGraph track for visualization in the UCSC genome browser:

--- a/workflows/scripts/control_freec_edit_config.py
+++ b/workflows/scripts/control_freec_edit_config.py
@@ -1,10 +1,13 @@
 import re
 import os
 import sys
+from sex import calc_sex
 
 
-def edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile, chrFiles, mappability, threads, output_config):
-    
+def edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile, chrFiles, mappability, threads, output_config, wgscovfile, ycovfile):
+    # Predict sex using calc_sex
+    pred_sex = calc_sex(wgscovfile, ycovfile)
+
     outdir = os.path.dirname(output_config)
     os.makedirs(outdir, exist_ok=True)
 
@@ -24,6 +27,7 @@ def edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile
     config_data = re.sub(r'^chrFiles =.*', f'chrFiles = {chrFiles}', config_data, flags=re.MULTILINE)
     config_data = re.sub(r'^gemMappabilityFile =.*', f'gemMappabilityFile = {mappability}', config_data, flags=re.MULTILINE)
     config_data = re.sub(r'^maxThreads =.*', f'maxThreads = {threads}', config_data, flags=re.MULTILINE)
+    config_data = re.sub(r'^sex =.*', f'sex = {"XY" if pred_sex == "male" else "XX"}', config_data, flags=re.MULTILINE)
     with open(output_config, 'w') as file:
         file.write(config_data)
 
@@ -40,5 +44,7 @@ if __name__ == "__main__":
     mappability = sys.argv[7]
     threads = sys.argv[8]
     output_config = sys.argv[9]
+    wgscovfile = sys.argv[10]
+    ycovfile = sys.argv[11]
 
-    edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile, chrFiles, mappability, threads, output_config)
+    edit_config(config_template, ploidy, tumor_pileup, normal_pileup, chrLenFile, chrFiles, mappability, threads, output_config, wgscovfile, ycovfile)

--- a/workflows/scripts/control_freec_makeGraph3.0.R
+++ b/workflows/scripts/control_freec_makeGraph3.0.R
@@ -127,7 +127,15 @@ ratio_adjusted <- ratio %>%
 # Calculate breaks and labels for the y-axis
 max_corr_ratio <- max(ratio_adjusted$corr_ratio, na.rm = TRUE)
 breaks <- seq(0, max_corr_ratio, by = 1)
-labels <- c(as.character(breaks[-length(breaks)]), paste0(">", max(breaks) - 1))
+
+# If the maximum ratio after correction is the same as before correction, 
+# it means the ratio is not adjusted and we can use the original labels
+if (max_corr_ratio == max(ratio_adjusted$Ratio * ploidy, na.rm = TRUE)) {
+  labels <- as.character(breaks)
+} else {
+  # Otherwise, we need to adjust the labels to reflect the correction
+  labels <- c(as.character(breaks[-length(breaks)]), paste0(">", max_corr_ratio - 1))
+}
 
 # Create the ratio plot
 Ratio_plot <- ggplot(fai) +                                              

--- a/workflows/scripts/control_freec_makeGraph3.0.R
+++ b/workflows/scripts/control_freec_makeGraph3.0.R
@@ -74,7 +74,14 @@ cytoband <- data.frame(read.table(cytoband, header = TRUE)) %>%
          ))
 
 # Calculate the ploidy based on the ratio data
-ploidy = median(ratio$CopyNumber[which(ratio$MedianRatio > 0.8 & ratio$MedianRatio < 1.2)], na.rm = TRUE)
+valid_ratio <- ratio %>% filter(MedianRatio > 0.8 & MedianRatio < 1.2)
+
+if (nrow(valid_ratio) > 0) {
+  ploidy <- median(valid_ratio$CopyNumber, na.rm = TRUE)
+} else {
+  ploidy <- 2  # Default ploidy value
+}
+
 cat(c("INFO: Selected ploidy:", ploidy, "\n"))
 
 # Calculate the most common increment value in the ratio data


### PR DESCRIPTION
## Add Ascat

### The What

Add Ascat CNA calling to the pipeline. Given the .bam input (tumor-normal or tumor-only) it will:
- in the ascat_run rule:
  - Calculate logR
  - Calculate BAF
  - Calculate CNA segments
 - in the ascat_plot rule, using the segments file and Rdata from the above calculation:
  - Generate (static) plot with CNA, logR and BAF
  - Output IGV compatible copy number file (here the minor and major allele copy numbers are summed)
  - Output IGV compatible BAF file

### The Why

We are still investigating a good replacement for Canvas. We ran into several issues with control-freec, so running them side by side will allow the geneticists to evaluate both

### The How

- Generate singularity
- Saved reference files from https://github.com/VanLoo-lab/ascat/tree/master/ReferenceFiles/WGS
- Use default ascat run settings to generate input for plotting
- Plot with ascat_custom_plot.R script

## Remove automated normal-only start

### The What

Remove the automated normal-only start

### The Why

Instead of wgs-somatic, the output from WOPR is used to evaluate normal-only wgs runs. 

### The How

In the wrapper() function of the wrapper, comment out the normal-only threads and end-threads. Add the skip to the log. It is still possible to start the normal-only runs from the manual wrapper start or by doing a launch_snakemake.py start.

## Continue wgs-somatic if control-freec fails

### The What

 Enable continuing of wgs-somatic even if control-freec fails

### The Why

control-freec can crash depending on the input data with the message: "Error: zero values to calculate medians...". I was unable to find more information about this crash but it seems to occur when the number of acceptably mapped reads is too low. The mappability regions, number of input reads, mapping quality and calculated ploidy all seem to affect it. We want wgs-somatic to be stable and continue even if control-freec crashes. 

### The How

- Generate (empty) outputs from the control_freec_run() rule if it crashes. 
- Enable the downstream rules to continue with the empty outputs.
- Others:
  - Also added the sex to the control-freec run. Thought low numbers of mapped reads on chrY was contributing to the problem. I am no longer sure if it did but running it sex-aware still makes sense.

## Others

- Remove checking of duplicate SVs from manta_summary.py
 - We already remove these earlier in filter_manta.py
 - There are cases where MATEID is not present in the table, crashing the pipeline (only MantaBND have MATEID information)


### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [X] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


### Tests
- [X] Tested ~30 tumor-normal samples (myeloid panel samples)
- [X] Tested wrapper start skipping normal-only
- [X] Tested manual wrapper start with normal-only
- [X] Tested tumor-only with downsampled files
