### PR TITLE
Handle empty excel file in manta summary downstream from empty vcf file

### DIFF
--- a/workflows/scripts/annotate_manta/manta_summary.py
+++ b/workflows/scripts/annotate_manta/manta_summary.py
@@ -9,6 +9,18 @@ def manta_summary(mantaSV_vcf, mantaSV_summary, tumorname, genelist, normalname=
     
     df = pd.read_excel(str(mantaSV_vcf),engine='openpyxl')
 
+    # Check for required columns
+    required_columns = ['ID', 'DEL/DUP Genecrossings', 'GeneInfo 1', 'GeneInfo 2', 'FORMAT', tumorname]
+    if normalname:
+        required_columns.append(normalname)
+    missing = [col for col in required_columns if col not in df.columns]
+    if missing:
+        print(f"Input Excel file is missing required columns: {missing}. Exiting manta_summary.")
+        # Create an empty summary Excel with just headers
+        with pd.ExcelWriter(str(mantaSV_summary)) as writer:
+            df.to_excel(writer, sheet_name="Manta_raw", engine='xlsxwriter')
+        return
+
     # drops rows with NA in columns ID. MATEID can be NA if not a translocation
     df = df.dropna(subset=['ID'])
 


### PR DESCRIPTION
### The What

Allow handling of an empty manta vcf file post filtering when creating the excel output files

### The Why

We are now filtering the manta vcf file that serves as an input to make the manta excel files:
- It is possible that the vcf file is empty post filtering
- The output excel files should also be empty instead of crashing

### The How

In annotate_manta_canvas.py:
- Check if the input vcf files are empty before accessing specific fields in the vcf dictionary 
- If it is empty write an empty excel file as output

In manta_summary.py:
- If the input excel file is lacking necessary columns:
  - Write an empty excel summary

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

### Tests

- Tested only on the run that crashed

