### PR TITLE
Add WGS admin QC summary

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -97,13 +97,13 @@ if tumorfastqdirs:
 if tumorid:
     if normalid:
         # Runs tn_workflow / paired if tumorid and normalid
-        localrules: all, upload_to_iva, tn_workflow, share_to_resultdir, excel_qc, tmb_calculation
+        localrules: all, upload_to_iva, tn_workflow, share_to_resultdir, excel_qc, tmb_calculation, qcstats_wgs_admin
     else:
         # Runs tumoronly_workflow if tumorid but not normalid
-        localrules: all, upload_to_iva, tumoronly_workflow, share_to_resultdir, excel_qc, tmb_calculation
+        localrules: all, upload_to_iva, tumoronly_workflow, share_to_resultdir, excel_qc, tmb_calculation, qcstats_wgs_admin
 else: 
     # Runs normalonly_workflow if normalid but not tumorid
-    localrules: all, upload_to_iva, normalonly_workflow, share_to_resultdir, excel_qc
+    localrules: all, upload_to_iva, normalonly_workflow, share_to_resultdir, excel_qc, qcstats_wgs_admin
 ###########################################################
 
 ########################################

--- a/configs/launcher_config.json
+++ b/configs/launcher_config.json
@@ -10,6 +10,7 @@
     "resultdir_hg38": "/webstore/clinical/routine/wgs_somatic/current",
     "resultdir_hg19": "/seqstore/webfolders/wgs/neuroblastom",
     "testresultdir" : "/medstore/projects/P23-075/wgs_somatic/local_repo/unit_tests/testoutput/resultdir", 
+    "wgsadmin_dir": "/webstore/clinical/routine/laboratory/current/quality_reports/", 
     "singularitybinddirs":
     {
         "sentieon":

--- a/configs/wrapper_config.yaml
+++ b/configs/wrapper_config.yaml
@@ -9,6 +9,8 @@ novaseq_A01736:
   demultiplex_path: "/seqstore/novaseq_A01736/Demultiplexdir/"
   seq_name_regex: '^[0-9]{6}_A01736_[0-9]{4}_.{10}(?:\+.{8})?$'
 
+outfolder_regex: '^[A-Z0-9]+\d{6,7}_\d{6}_[A-Z0-9]{10}_\d{6}-\d{6}$'
+
 previous_runs_file_path: '../runlists/novaseq_runlist.txt'
 wrapper_log_path: '/clinical/exec/wgs_somatic/logs'
 

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -368,6 +368,7 @@ def analysis_main(args, outputdir, normalname=False, normalfastqs=False, tumorna
             "--bind", "/seqstore",
             "--bind", "/apps",
             "--bind", "/clinical",
+            "--bind", "/webstore",
         ]
 
         cluster_args = [

--- a/tools/custom_email.py
+++ b/tools/custom_email.py
@@ -16,6 +16,21 @@ def send_email(subject, body):
     msg['To'] = "gms_btb@gu.se, su.vokliniskgen.wgsadmin@vgregion.se, susanne.fransson@vgregion.se" # TODO Get from config and have different recipients for errors and success
     msg['Cc'] = "cgg-cancer@gu.se" # TODO Get from config
 
+    # Send the message
+    s = smtplib.SMTP('smtp.gu.se')
+    s.send_message(msg)
+    s.quit()
+    
+def send_email_qc(subject, body):
+    """Send a simple email."""
+
+    msg = EmailMessage()
+    msg.set_content(body)
+
+    msg['Subject'] = subject
+    msg['From'] = "cgg-cancer@gu.se" # TODO Get from config
+    msg['Cc'] = "cgg-cancer@gu.se"
+    msg['To'] = "su.vokliniskgen.wgsadmin@vgregion.se"
 
     # Send the message
     s = smtplib.SMTP('smtp.gu.se')
@@ -66,3 +81,14 @@ CGG Cancer
 """
 
     send_email(subject, body)
+
+def error_admin_qc_email(run_name):
+    """Send an email when the generating the qd admin summary report fails"""
+
+    subject = f'WGS somatic - admin QC failed {run_name}'
+
+    body = f"""Generating the WGS Admin QC report failed for run {run_name}.\n
+Please create the report manually.\n
+    """
+    
+    send_email_qc(subject, body)

--- a/tools/wgs_admin_summary/combine_wgsadmin_qc_summary.py
+++ b/tools/wgs_admin_summary/combine_wgsadmin_qc_summary.py
@@ -1,0 +1,154 @@
+import os
+import pandas as pd
+import click
+import json
+import logging
+from collections import defaultdict
+import re
+
+def setup_logging(log_dir):
+    os.makedirs(log_dir, exist_ok=True)
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s - %(levelname)s - %(message)s",
+        handlers=[
+            logging.FileHandler(os.path.join(log_dir, "combine_wgsadmin_qc_summary.log")),
+            logging.StreamHandler()
+        ]
+    )
+
+def combine_qc_stats(launcher_config, runtag_results, base_directory=None, output_directory=None, logger=None,regex=None):
+    """
+    Command-line tool to combine '_qc_stats_wgsadmin.xlsx' files for each runtag in the given BASE_DIRECTORY.
+    """
+    # Load launcher_config once and parse it
+    try:
+        with open(launcher_config, 'r') as launcher_config_file:
+            config_data = json.load(launcher_config_file)
+    except (FileNotFoundError, json.JSONDecodeError) as e:
+        raise FileNotFoundError(f"Launcher config not found or invalid: {e}")
+    
+    if not logger:
+        setup_logging(config_data.get('logdir'))
+        logger = logging.getLogger(__name__)
+    
+    logger.info("Starting WGS admin QC summary per run")
+    
+    # If output_directory is not provided, read it from the launcher_config
+    # If base_directory is not provided, read it from the launcher_config
+    try:
+        if output_directory is None:
+            output_directory = config_data.get('wgsadmin_dir')
+            if output_directory is None:
+                raise KeyError("Key 'wgsadmin_dir' not found in launcher_config.")
+        if base_directory is None:
+            base_directory = config_data.get('resultdir_hg38')
+            if base_directory is None:
+                raise KeyError("Key 'resultdir_hg38' not found in launcher_config.")
+    except KeyError as e:
+        raise FileNotFoundError(f"Launcher config missing required key: {e}")
+        
+    logger.info(f"Base directory: {base_directory}")
+    logger.info(f"Output directory: {output_directory}")
+    
+    # Dictionary to store dataframes for each runtag
+    runtag_dataframes = defaultdict(list)
+
+    if runtag_results:
+        runtag_parts = runtag_results.split("+")[0].split("_")
+        input_runtag = f"{runtag_parts[0]}_{runtag_parts[3]}"
+    else:
+        input_runtag = None
+
+    # Walk through all subdirectories in the base directory
+    for root, dirs, files in os.walk(base_directory):
+        # Extract the runtag (second and third parts of the current directory name)
+        parent_dir = os.path.basename(root)
+        if regex and re.match(regex, parent_dir):
+            parts = parent_dir.split('_')
+            current_runtag = f"{parts[1]}_{parts[2]}"
+            # If a specific runtag is provided, skip directories that don't match exactly
+            if input_runtag and current_runtag != input_runtag:
+                # logger.info(f"Skipping directory: {root} as it does not match the specified runtag: {input_runtag}")
+                continue
+
+            logger.info(f"Processing directory: {root} for runtag: {current_runtag}")
+
+            # Find all matching files in the current directory
+            matching_files = [file for file in files if file.endswith("_qc_stats_wgsadmin.xlsx")]
+
+            # Skip the directory if no matching files are found
+            if not matching_files:
+                logger.warning(f"No '_qc_stats_wgsadmin.xlsx' files found in {root}. Skipping...")
+                continue
+
+            # Process each matching file
+            for file in matching_files:
+                file_path = os.path.join(root, file)
+                try:
+                    df = pd.read_excel(file_path)
+                    runtag_dataframes[current_runtag].append((file_path, df))
+                    logger.info(f"Successfully read file: {file_path}")
+                except Exception as e:
+                    logger.error(f"Error reading {file_path}: {e}")
+
+    if not runtag_dataframes:
+        raise RuntimeError(f"No QC summary files found for runtag {input_runtag}")
+    
+    os.makedirs(output_directory, exist_ok=True)
+
+    # Combine and save the dataframes for each runtag
+    for runtag, file_dataframes in runtag_dataframes.items():
+        logger.info(f"Processing runtag: {runtag} with {len(file_dataframes)} files")
+        
+        output_file_xlsx = os.path.join(output_directory, f"{runtag}_wgs_somatic_qc_summary.xlsx")
+        output_file_tsv = os.path.join(output_directory, f"{runtag}_wgs_somatic_qc_summary.tsv")
+        
+        if os.path.exists(output_file_xlsx):
+            logger.info(f"Existing combined file found for runtag {runtag}: {output_file_xlsx}")
+            # Read the existing combined file
+            existing_df = pd.read_excel(output_file_xlsx)
+            combined_df = existing_df
+            # newer_file_detected = False
+            new_content_detected = False
+            for file_path, new_df in file_dataframes:
+                # check if the content of the files in the directory is already in the combined file
+                if not new_df.isin(existing_df.to_dict(orient='list')).all().all():
+                    logger.info(f"New content detected in file: {file_path}. Combining with existing summary.")
+                    combined_df = pd.concat([combined_df, new_df], ignore_index=True).drop_duplicates()
+                    new_content_detected = True
+                else:
+                    logger.info(f"Skipping {file_path} as its content is already present in the existing combined file.")
+            
+            if not new_content_detected:
+                logger.info(f"No new content detected for runtag {runtag}. Skipping...")
+                continue
+        else:
+            logger.info(f"No existing combined file found for runtag {runtag}. Creating a new one.")
+            # Combine all new dataframes if no existing file
+            combined_df = pd.concat([df for _, df in file_dataframes], ignore_index=True).drop_duplicates()
+        
+        # Save the combined file
+        combined_df.to_excel(output_file_xlsx, index=False)
+        combined_df.to_csv(output_file_tsv, sep='\t', index=False)
+        logger.info(f"Combined files saved for runtag {runtag}: {output_file_xlsx} and {output_file_tsv}")
+
+    logger.info("Finished WGS admin QC summary summary per run.")
+
+@click.command()
+@click.option('--launcher_config', required=True, help='Path to launcher config JSON file.')
+@click.option('--runtag_results', required=False, help='Runtag of the directories to process.')
+@click.option('--base_directory', required=False, help='Base directory to search for QC files.')
+@click.option('--output_directory', required=False, help='Directory to save combined summary files.')
+@click.option('--regex', required=False, help='Regex to match directory names.')
+def cli(launcher_config, runtag_results, base_directory, output_directory, regex):
+    combine_qc_stats(
+        launcher_config=launcher_config,
+        runtag_results=runtag_results,
+        base_directory=base_directory,
+        output_directory=output_directory,
+        regex=regex
+    )
+
+if __name__ == "__main__":
+    cli()

--- a/workflows/rules/qc/aggregate_qc.smk
+++ b/workflows/rules/qc/aggregate_qc.smk
@@ -1,63 +1,86 @@
-# vim: syntax=python tabstop=4 expandtab
-# coding: utf-8
+# # vim: syntax=python tabstop=4 expandtab
+# # coding: utf-8
 
-from workflows.scripts.create_qc_excel import create_excel_main
+from workflows.scripts.create_qc_excel import create_excel_main, create_qc_toaggregate
 import os
 
+# set name of output qc files taking into account if tumorid or normalid exist
 if tumorid:
-    if normalid:
-        # excel_qc rule for paired analysis
-        rule excel_qc:
-            input:
-                tumorcov = expand("{stype}/reports/{sname}_WGScov.tsv", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
-                ycov = expand("{stype}/reports/{sname}_Ycov.tsv", stype=sampleconfig[normalname]["stype"], sname=normalid),
-                normalcov = expand("{stype}/reports/{sname}_WGScov.tsv", stype=sampleconfig[normalname]["stype"], sname=normalid),
-                tumordedup = expand("{stype}/dedup/{sname}_DEDUP.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
-                normaldedup = expand("{stype}/dedup/{sname}_DEDUP.txt", stype=sampleconfig[normalname]["stype"], sname=normalid),
-                tumorvcf = expand("{stype}/dnascope/{sname}_germline_SNVsOnly.recode.vcf", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
-                normalvcf = expand("{stype}/dnascope/{sname}_germline_SNVsOnly.recode.vcf", stype=sampleconfig[normalname]["stype"], sname=normalid),
-                canvasvcf = expand("{stype}/canvas/{sname}_CNV_somatic.vcf", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
-                insilicofile = expand("{stype}/insilico/{insiliconame}/{sname}_{insiliconame}_genes_below10x.xlsx", stype=sampleconfig[normalname]["stype"], insiliconame=sampleconfig["insilico"], sname=normalid),
-                tmb = expand("{stype}/reports/{sname}_tmb.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
-                msi_filtered = expand("{stype}/msi/{sname}_msi_filtered.txt", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-                msi = expand("{stype}/msi/{sname}_msi.txt", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
-                tumor_info_files = expand("{stype}/control-freec_{ploidy}/{sname}_REALIGNED.bam_info.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid, ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-            output:
-                temp("qc_report/{tumorname}_qc_stats.xlsx")
-            run:
-                my_insilicofile = f"{input.insilicofile}".split(" ", 1)[0]
-                insilicodir = os.path.dirname(f"{my_insilicofile}").rsplit("/", 1)[0] # Somehow this stuff works
-                create_excel_main(tumorcov = f"{input.tumorcov}", ycov = f"{input.ycov}" , normalcov = f"{input.normalcov}", tumordedup = f"{input.tumordedup}", normaldedup = f"{input.normaldedup}", tumorvcf = f"{input.tumorvcf}", normalvcf = f"{input.normalvcf}", canvasvcf = f"{input.canvasvcf}", tmb = f"{input.tmb}", msi = f"{input.msi}", msi_red = f"{input.msi_filtered}", tumor_info_files=[f"{file}" for file in input.tumor_info_files], output = f"{output}", insilicodir = f"{insilicodir}") 
-    else:
-        # excel_qc rule for tumor only
-        rule excel_qc:
-            input:
-                tumorcov = expand("{stype}/reports/{sname}_WGScov.tsv", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
-                ycov = expand("{stype}/reports/{sname}_Ycov.tsv", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
-                tumordedup = expand("{stype}/dedup/{sname}_DEDUP.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
-                tumorvcf = expand("{stype}/dnascope/{sname}_germline_SNVsOnly.recode.vcf", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
-                insilicofile = expand("{stype}/insilico/{insiliconame}/{sname}_{insiliconame}_genes_below10x.xlsx", stype=sampleconfig[tumorname]["stype"], insiliconame=sampleconfig["insilico"], sname=tumorid),
-                tmb = expand("{stype}/reports/{sname}_tmb.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid),
-                tumor_info_files = expand("{stype}/control-freec_{ploidy}/{sname}_REALIGNED.bam_info.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid, ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
-            output:
-                temp("qc_report/{tumorname}_qc_stats.xlsx")
-            run:
-                my_insilicofile = f"{input.insilicofile}".split(" ", 1)[0]
-                insilicodir = os.path.dirname(f"{my_insilicofile}").rsplit("/", 1)[0] # Somehow this stuff works
-                create_excel_main(tumorcov = f"{input.tumorcov}", ycov = f"{input.ycov}", tumordedup = f"{input.tumordedup}", tumorvcf = f"{input.tumorvcf}", tmb = f"{input.tmb}", tumor_info_files=[f"{file}" for file in input.tumor_info_files], output = f"{output}", insilicodir = f"{insilicodir}")
-
+    excel_qc_output = temp("qc_report/{tumorname}_qc_stats.xlsx")
+    qcstats_wgs_admin_output = temp("qc_report/{tumorname}_qc_stats_wgsadmin.xlsx")
 else:
-    # excel_qc rule for normal only
-    rule excel_qc:
-        input:
-            normalcov = expand("{stype}/reports/{sname}_WGScov.tsv", stype=sampleconfig[normalname]["stype"], sname=normalid),
-            ycov = expand("{stype}/reports/{sname}_Ycov.tsv", stype=sampleconfig[normalname]["stype"], sname=normalid),
-            normaldedup = expand("{stype}/dedup/{sname}_DEDUP.txt", stype=sampleconfig[normalname]["stype"], sname=normalid),
-            normalvcf = expand("{stype}/dnascope/{sname}_germline_SNVsOnly.recode.vcf", stype=sampleconfig[normalname]["stype"], sname=normalid),
-            insilicofile = expand("{stype}/insilico/{insiliconame}/{sname}_{insiliconame}_genes_below10x.xlsx", stype=sampleconfig[normalname]["stype"], insiliconame=sampleconfig["insilico"], sname=normalid),
-        output:
-            temp("qc_report/{normalname}_qc_stats.xlsx")
-        run:
-            my_insilicofile = f"{input.insilicofile}".split(" ", 1)[0]
-            insilicodir = os.path.dirname(f"{my_insilicofile}").rsplit("/", 1)[0] # Somehow this stuff works
-            create_excel_main(normalcov = f"{input.normalcov}", ycov = f"{input.ycov}", normaldedup = f"{input.normaldedup}", normalvcf =f"{input.normalvcf}", output = f"{output}", insilicodir = f"{insilicodir}")
+    excel_qc_output = temp("qc_report/{normalname}_qc_stats.xlsx")
+    qcstats_wgs_admin_output = temp("qc_report/{normalname}_qc_stats_wgsadmin.xlsx")
+
+
+rule excel_qc:
+    input: # the empty input is given as an empty list and not string because snakemake interprets "" as a missing file, instead of "no input"
+        tumorcov = expand("{stype}/reports/{sname}_WGScov.tsv", stype=sampleconfig[tumorname]["stype"], sname=tumorid) if tumorid else [],
+        ycov = expand("{stype}/reports/{sname}_Ycov.tsv", stype=sampleconfig[(normalname if normalid else tumorname)]["stype"], sname=(normalid if normalid else tumorid)),
+        normalcov = expand("{stype}/reports/{sname}_WGScov.tsv", stype=sampleconfig[normalname]["stype"], sname=normalid) if normalid else [],
+        tumordedup = expand("{stype}/dedup/{sname}_DEDUP.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid) if tumorid else [],
+        normaldedup = expand("{stype}/dedup/{sname}_DEDUP.txt", stype=sampleconfig[normalname]["stype"], sname=normalid) if normalid else [],
+        tumorvcf = expand("{stype}/dnascope/{sname}_germline_SNVsOnly.recode.vcf", stype=sampleconfig[tumorname]["stype"], sname=tumorid) if tumorid else [],
+        normalvcf = expand("{stype}/dnascope/{sname}_germline_SNVsOnly.recode.vcf", stype=sampleconfig[normalname]["stype"], sname=normalid) if normalid else [],
+        canvasvcf = expand("{stype}/canvas/{sname}_CNV_somatic.vcf", stype=sampleconfig[tumorname]["stype"], sname=tumorid) if tumorid and normalid else [],
+        insilicofile = expand("{stype}/insilico/{insiliconame}/{sname}_{insiliconame}_genes_below10x.xlsx", stype=sampleconfig[(normalname if normalid else tumorname)]["stype"], insiliconame=sampleconfig["insilico"], sname=(normalid if normalid else tumorid)),
+        tmb = expand("{stype}/reports/{sname}_tmb.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid) if tumorid else [],
+        msi_filtered = expand("{stype}/msi/{sname}_msi_filtered.txt", sname=tumorid, stype=sampleconfig[tumorname]["stype"]) if tumorid and normalid else [],
+        msi = expand("{stype}/msi/{sname}_msi.txt", sname=tumorid, stype=sampleconfig[tumorname]["stype"]) if tumorid and normalid else [],
+        tumor_info_files = expand("{stype}/control-freec_{ploidy}/{sname}_REALIGNED.bam_info.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid, ploidy=pipeconfig["rules"]["control-freec"]["ploidy"]),
+    output:
+        excel_qc_output
+    run:
+        # Determine the insilico directory if applicable
+        my_insilicofile = f"{input.insilicofile}".split(" ", 1)[0] if "insilicofile" in input else None
+        insilicodir = os.path.dirname(f"{my_insilicofile}").rsplit("/", 1)[0] if my_insilicofile else None
+
+        # Call create_excel_main with all inputs
+        create_excel_main(
+            tumorcov=f"{input.tumorcov}",
+            ycov=f"{input.ycov}",
+            normalcov=f"{input.normalcov}",
+            tumordedup=f"{input.tumordedup}",
+            normaldedup=f"{input.normaldedup}",
+            tumorvcf=f"{input.tumorvcf}",
+            normalvcf=f"{input.normalvcf}",
+            canvasvcf=f"{input.canvasvcf}",
+            tmb=f"{input.tmb}",
+            msi=f"{input.msi}",
+            msi_red=f"{input.msi_filtered}",
+            output=f"{output}",
+            insilicodir=f"{insilicodir}",
+            tumor_info_files=[file for file in input.tumor_info_files]
+        )
+
+rule qcstats_wgs_admin:
+# Rule to create a QC report for WGS admin
+# works for tumor+normal, tumor-only and normal-only
+    input: 
+        tumorcov = expand("{stype}/reports/{sname}_WGScov.tsv", stype=sampleconfig[tumorname]["stype"], sname=tumorid) if tumorid else [],
+        ycov = expand("{stype}/reports/{sname}_Ycov.tsv", stype=sampleconfig[(normalname if normalid else tumorname)]["stype"], sname=(normalid if normalid else tumorid)),
+        normalcov = expand("{stype}/reports/{sname}_WGScov.tsv", stype=sampleconfig[normalname]["stype"], sname=normalid) if normalid else [],
+        tumordedup = expand("{stype}/dedup/{sname}_DEDUP.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid) if tumorid else [],
+        normaldedup = expand("{stype}/dedup/{sname}_DEDUP.txt", stype=sampleconfig[normalname]["stype"], sname=normalid) if normalid else [],
+        tumorvcf = expand("{stype}/dnascope/{sname}_germline_SNVsOnly.recode.vcf", stype=sampleconfig[tumorname]["stype"], sname=tumorid) if tumorid else [],
+        normalvcf = expand("{stype}/dnascope/{sname}_germline_SNVsOnly.recode.vcf", stype=sampleconfig[normalname]["stype"], sname=normalid) if normalid else [],
+        tmb = expand("{stype}/reports/{sname}_tmb.txt", stype=sampleconfig[tumorname]["stype"], sname=tumorid) if tumorid else [],
+    output: 
+        qcstats_wgs_admin_output
+    params:
+        tumorid = tumorid if tumorid else '',
+        normalid = normalid if normalid else ''
+    run: 
+        create_qc_toaggregate(
+        tumorcov=f"{input.tumorcov}",
+        ycov=f"{input.ycov}",
+        normalcov=f"{input.normalcov}" ,
+        tumordedup=f"{input.tumordedup}" ,
+        normaldedup=f"{input.normaldedup}" ,
+        tumorvcf=f"{input.tumorvcf}" ,
+        normalvcf=f"{input.normalvcf}" ,
+        tmb=f"{input.tmb}" ,
+        output=f"{output}",
+        tumorid = f"{params.tumorid}",
+        normalid = f"{params.normalid}"
+        )

--- a/workflows/rules/results_sharing/share_to_resultdir.smk
+++ b/workflows/rules/results_sharing/share_to_resultdir.smk
@@ -12,6 +12,7 @@ if tumorid:
                 expand("{stype}/{caller}/{sname}_{vcftype}.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], stype=sampleconfig[tumorname]["stype"], caller="tnscope", sname=tumorid, vcftype="somatic"),
                 expand("{stype}/{caller}/{sname}_{vcftype}_refseq3kfilt.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], stype=sampleconfig[normalname]["stype"], caller="dnascope", sname=normalid, vcftype="germline"),
                 expand("qc_report/{tumorname}_qc_stats.xlsx", tumorname=tumorname),
+                expand("qc_report/{tumorname}_qc_stats_wgsadmin.xlsx", tumorname=tumorname),
                 expand("{stype}/canvas/{sname}_CNV_somatic.vcf.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/canvas/{sname}_CNV_germline.vcf.xlsx", sname=normalid, stype=sampleconfig[normalname]["stype"]),
                 expand("{stype}/manta/{sname}_somatic_mantaSV.vcf", sname=tumorid, stype=sampleconfig[tumorname]["stype"]), 
@@ -48,6 +49,7 @@ if tumorid:
             input:
                 expand("{stype}/{caller}/{sname}_{vcftype}_refseq3kfilt.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], stype=sampleconfig[tumorname]["stype"], caller="tnscope", sname=tumorid, vcftype="somatic"),
                 expand("qc_report/{tumorname}_qc_stats.xlsx", tumorname=tumorname),
+                expand("qc_report/{tumorname}_qc_stats_wgsadmin.xlsx", tumorname=tumorname),
                 expand("{stype}/canvas/{sname}_CNV_germline.vcf.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
                 expand("{stype}/manta/{sname}_somatic_mantaSV.vcf", sname=tumorid, stype=sampleconfig[tumorname]["stype"]), 
                 expand("{stype}/manta/{sname}_somatic_mantaSV.vcf.xlsx", sname=tumorid, stype=sampleconfig[tumorname]["stype"]),
@@ -77,6 +79,7 @@ else:
         input:
             expand("{stype}/{caller}/{sname}_{vcftype}_refseq3kfilt.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], stype=sampleconfig[normalname]["stype"], caller="dnascope", sname=normalid, vcftype="germline"),
             expand("qc_report/{normalname}_qc_stats.xlsx", normalname=normalname),
+            expand("qc_report/{normalname}_qc_stats_wgsadmin.xlsx", normalname=normalname),
             expand("{stype}/canvas/{sname}_CNV_germline.vcf.xlsx", sname=normalid, stype=sampleconfig[normalname]["stype"]),
             expand("{stype}/dnascope/{sname}_{hgX}_SNV_CNV_germline.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=normalid, stype=sampleconfig[normalname]["stype"], hgX=reference),
             expand("{stype}/canvas/{sname}_CNV_germline.{fmt}", fmt=["vcf.gz", "vcf.gz.csi"], sname=normalid, vartype="germline", stype=sampleconfig[normalname]["stype"]),

--- a/workflows/scripts/create_qc_excel.py
+++ b/workflows/scripts/create_qc_excel.py
@@ -353,6 +353,70 @@ def create_excel_main(tumorcov='', ycov='', normalcov='', tumordedup='', normald
         create_excel(statsdict, output, normalname, sex=calculated_sex)
         add_insilico_stats(insilicodir, output)
 
+def create_qc_toaggregate(tumorcov='', ycov='', normalcov='', tumordedup='', normaldedup='', tumorvcf='', normalvcf='', output='', tmb = '', tumorid = '', normalid = ''):
+
+    statsdict = {}
+    if tumorcov:
+        statsdict = extract_stats(tumorcov, "coverage",  "tumor", statsdict)
+        statsdict = extract_stats(tumordedup, "dedup",  "tumor", statsdict)
+        tmb_dict = read_tmb_file(tmb)
+        if normalcov:
+            calculated_sex = calc_sex(normalcov, ycov)
+            match_dict = determine_match(normalvcf, tumorvcf, 400000)
+        else:
+            calculated_sex = calc_sex(tumorcov, ycov)
+            
+    if normalcov:
+        statsdict = extract_stats(normalcov, "coverage", "normal", statsdict)
+        statsdict = extract_stats(normaldedup, "dedup", "normal", statsdict)
+        if not tumorcov:
+            calculated_sex = calc_sex(normalcov, ycov)
+
+    # Prepare data for tumor and normal rows
+    rows = []
+
+    if tumorcov:
+        tumor_row = {
+            "Type": "Tumor",
+            "SampleID": tumorid,
+            "Sex": calculated_sex if normalcov else "N/A",
+            "Coverage 10x": next((item["colvalue"] for item in statsdict["coverage"]["tumor"].values() if item["colname"] == "PCT_10X"), "N/A"),
+            "Coverage 30x": next((item["colvalue"] for item in statsdict["coverage"]["tumor"].values() if item["colname"] == "PCT_30X"), "N/A"),
+            "Coverage 60x": next((item["colvalue"] for item in statsdict["coverage"]["tumor"].values() if item["colname"] == "PCT_60X"), "N/A"),
+            "Mean coverage": next((item["colvalue"] for item in statsdict["coverage"]["tumor"].values() if item["colname"] == "MEAN_COVERAGE"), "N/A"),
+            "Median coverage": next((item["colvalue"] for item in statsdict["coverage"]["tumor"].values() if item["colname"] == "MEDIAN_COVERAGE"), "N/A"),
+            "SD coverage": next((item["colvalue"] for item in statsdict["coverage"]["tumor"].values() if item["colname"] == "SD_COVERAGE"), "N/A"),
+            "Match fraction": match_dict["match_fraction"] if normalcov else "N/A",
+            "Match status": match_dict["match_status"] if normalcov else "N/A",
+            "TMB": tmb_dict.get("TMB", "N/A"),
+        }
+        rows.append(tumor_row)
+
+    if normalcov:
+        normal_row = {
+            "Type": "Normal",
+            "SampleID": normalid,
+            "Sex": calculated_sex,
+            "Coverage 10x": next((item["colvalue"] for item in statsdict["coverage"]["normal"].values() if item["colname"] == "PCT_10X"), "N/A"),
+            "Coverage 30x": next((item["colvalue"] for item in statsdict["coverage"]["normal"].values() if item["colname"] == "PCT_30X"), "N/A"),
+            "Coverage 60x": next((item["colvalue"] for item in statsdict["coverage"]["normal"].values() if item["colname"] == "PCT_60X"), "N/A"),
+            "Mean coverage": next((item["colvalue"] for item in statsdict["coverage"]["normal"].values() if item["colname"] == "MEAN_COVERAGE"), "N/A"),
+            "Median coverage": next((item["colvalue"] for item in statsdict["coverage"]["normal"].values() if item["colname"] == "MEDIAN_COVERAGE"), "N/A"),
+            "SD coverage": next((item["colvalue"] for item in statsdict["coverage"]["normal"].values() if item["colname"] == "SD_COVERAGE"), "N/A"),
+            "Match fraction": match_dict["match_fraction"] if tumorcov else "N/A",
+            "Match status": match_dict["match_status"] if tumorcov else "N/A",
+            "TMB": "N/A",
+        }
+        rows.append(normal_row)
+
+    if not output.endswith(".xlsx"):
+        output = f"{output}.xlsx"
+    # Create a DataFrame and save to Excel
+    df = pd.DataFrame(rows, columns=["Type", "SampleID", "Sex", "Coverage 10x", "Coverage 30x", "Coverage 60x", "Mean coverage", "Median coverage", "SD coverage", "Match fraction", "Match status", "TMB"])
+    df.to_excel(output, index=False)
+    # Save to TSV
+    tsv_output = output.replace(".xlsx", ".tsv")
+    df.to_csv(tsv_output, sep="\t", index=False)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
## Contents
This pull request introduces functionality for generating and managing WGS admin QC summary reports, along with several related updates to configuration files, email handling, and logging. 
See https://github.com/ClinicalGenomicsGBG/wgs_somatic/pull/103 for the previous review

### New WGS Admin QC Summary Functionality:
* Added `combine_wgsadmin_qc_summary.py` to process and combine `_qc_stats_wgsadmin.xlsx` files per run, including setup for logging, handling runtag-specific data, and saving combined reports in both `.xlsx` and `.tsv` formats.
* Integrated the QC summary functionality into the `wgs_somatic-run-wrapper.py`, including error handling and email notifications for failures. 

### Configuration Updates:
* Updated `launcher_config.json` to include a new `wgsadmin_dir` key for specifying the output directory for QC reports.
* Added `outfolder_regex` to `wrapper_config.yaml` to define a regex pattern for identifying valid output directories.

### Email Enhancements:
* Added a new `send_email_qc` function for sending QC-specific emails and an `error_admin_qc_email` function for notifying failures in generating QC reports. [[1]](diffhunk://#diff-4d9bfaf046e630bb2ddad236a84c065da265892256a5815fa93ff136931233bdR19-R33) [[2]](diffhunk://#diff-4d9bfaf046e630bb2ddad236a84c065da265892256a5815fa93ff136931233bdR84-R94)

### Workflow and Rule Adjustments:
* Updated `Snakefile` to include `qcstats_wgs_admin` as a local rule to create the QC summary per analysis

### Minor Improvements:
* Added `/webstore` to the list of directories bound in `launch_snakemake.py` to support the new QC functionality.


### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [x] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Tests
Tested:
- standalone run
- wrapper run tumor+normal and tumor only
  - Also test run where only the QC report failed and two emails were sent as expected: successful run + failed combined qc report

### Expected outcome
- QC summary will be created per analysis as part of the snakemake workflow
- QC summary will be created per run (combining the QC summaries from different sample(s) of the same run)
- QC summary per run is saved in a location accessible by the wgs admin

