### PR TITLE
Fix duplicate breakends

### DIFF
--- a/workflows/scripts/filter_manta.py
+++ b/workflows/scripts/filter_manta.py
@@ -74,7 +74,8 @@ def filter_vcf(input_vcf, output_vcf, tumor_name=None, normal_name=None, min_tum
             if record.info.get("SVTYPE") == "BND" and "MATEID" in record.info:
                 id1 = record.id
                 id2 = record.info["MATEID"]
-                # Create a sorted tuple so (a, b) and (b, a) are the same
+                if isinstance(id2, (tuple, list)):
+                    id2 = id2[0]
                 pair = tuple(sorted([id1, id2]))
                 if pair in seen_bnd_ids:
                     continue  # Skip duplicate


### PR DESCRIPTION
### The What

Fix duplicate breakends

### The Why

**Some of the reciprocal breakends are still passing filtering even though they should not.** 

For example:

| Varianttype | Breakpoint 1 | Breakpoint 2| ID | MateID |
| ----------- | ----------------- | --------------- | ----------------------------- | ---------------------------- |
| MantaBND | chr1:204685490 | chr16:2176067 | MantaBND:16272:0:1:0:0:0:1 | MantaBND:16272:0:1:0:0:0:0 |
| MantaBND | chr16:2176064 | chr1:204685493 | MantaBND:16272:0:1:0:0:0:0 | MantaBND:16272:0:1:0:0:0:1 |

In the previous versions (wgs-somatic ≤ 2.8.2) we filtered based on the ID and MateID. In the new `filter_manta.py` code we filter based on the locations of the breakends which can apparently vary slightly even for otherwise duplicate breakends

### The How

- Use the ID and MateID (record.id and record.info["MATEID"][0] in pysam)
- make a tuple out of the pair and check that it does not already exist
- If it already exists, do not add it to the output vcf

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

### Tests

- [X] Tested with the MOL249 sample, verified that the same SVs were filtered as in wgs-somatic v2.8.2
