### PR TITLE
Fix: running from /home (or elsewhere)

### DIFF
--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -14,7 +14,7 @@ import stat
 import yaml
 import random
 import string
-from definitions import LAUNCHER_CONFIG_PATH
+from definitions import LAUNCHER_CONFIG_PATH, ROOT_DIR
 
 
 def get_time():
@@ -399,6 +399,7 @@ def analysis_main(args, outputdir, normalname=False, normalfastqs=False, tumorna
             "--bind", "/apps",
             "--bind", "/clinical",
             "--bind", "/webstore",
+            "--bind", ROOT_DIR
         ]
 
         cluster_args = [


### PR DESCRIPTION

### The What

Enable running the pipeline from e.g. /home or /oldseqstore. Previously ascat was crashing because it could not access the ROOT_DIR/scripts directory.

### The Why

Make the pipeline more portable without specifying all possible paths in the --binds

### The How

Add ROOT_DIR to the --binds which will always be where the pipeline is located

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [ ] **MINOR** - when you add functionality in a backwards compatible manner
- [X] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Tests

Tested with testfiles for a tumor-normal run from /home
