### PR TITLE
Fix  run qc summary on workdirs

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,19 @@ For paired tumor and normal FASTQs, the results contain:
 module load micromamba
 micromamba activate /clinical/exec/wgs_somatic/env/wgs_somatic_env/
 
-python wgs_somatic-run-wrapper.py --tumorsample DNAtumor [--normalsample DNAnormal] [-o outpath] [--copyresults]
+python wgs_somatic-run-wrapper.py \
+  -t DNAtumor \
+  [-n DNAnormal] \
+  [-o outpath] \
+  [--copyresults] \
+  [--qcsummary]
 ```
 
 - The wrapper will automatically download and decompress fastqs where necessary
 - The output will be in `/clinical/data/wgs_somatic/manual/` unless specified with `-o`
+- If you only specify -t or -n a tumor-only or normal-only run will be performed, respectively
 - The output is not copied to webstore, unless `--copyresults` is added to the command
+- A QCsummary of the run is provided on webstore for the laboratory if `--qcsummary` is provided
 
 ### Standalone snakemake run
 
@@ -121,6 +128,23 @@ The pipeline is started automatically when new runs with GMS-BT/AL samples appea
 Cron runs every 30 minutes (in crontab of cronuser)
 
 Wrapper script `wgs_somatic-run-wrapper.py` looks for runs in Demultiplexdir. Every time there is a new run in Demultiplexdir, it is added to text file `/clinical/exec/wgs_somatic/runlists/novaseq_runlist.txt` to keep track of which runs that have already been analyzed. If a new run has GMS-BT/AL samples, the pipeline starts for these samples. Output is placed in working directory `/clinical/data/wgs_somatic/cron/` and the final result files are then copied to webstore. You can find a more detailed description of the automation on GMS-BT confluence page.
+
+## wgsadmin QC stats
+
+A summary of the QC stats is generated for WGSadmin, who will check to make sure the completed run adheres to the required specifications (e.g. coverage, match check). By default the wrapper generates a combined summary for all runs in the batch.
+
+When running the wrapper manually it is also possible to specify `-q`|`--qcsummary` to generate the QCsummary.
+
+For standalone snakemake runs you can run the `combine_wgsadmin_summary` module on the outputdirs:
+
+```{bash}
+module load micromamba
+micromamba activate /clinical/exec/wgs_somatic/env/wgs_somatic_env
+
+python -m tools.wgs_admin_summary.combine_wgsadmin_qc_summary \
+  --qc-summary-directory /path/to/qc_summary_outputdir \
+  -o outputdir1 -o outputdir2 -o outputdir3
+```
 
 ## Yearly statistics
 

--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ python wgs_somatic-run-wrapper.py \
 - The wrapper will automatically download and decompress fastqs where necessary
 - The output will be in `/clinical/data/wgs_somatic/manual/` unless specified with `-o`
 - If you only specify -t or -n a tumor-only or normal-only run will be performed, respectively
-- The output is not copied to webstore, unless `--copyresults` is added to the command
-- A QCsummary of the run is provided on webstore for the laboratory if `--qcsummary` is provided
+- If `--copyresults` is included, the results will be copied to webstore `configs/launcher_config.json: "resultdir_hg38"`
+- if `--qcsummary` is included, a QCsummary of the run is provided on webstore for the laboratory `configs/launcher_config.json: "wgsadmin_dir"`
 
 ### Standalone snakemake run
 

--- a/configs/wrapper_config.yaml
+++ b/configs/wrapper_config.yaml
@@ -9,8 +9,6 @@ novaseq_A01736:
   demultiplex_path: "/seqstore/novaseq_A01736/Demultiplexdir/"
   seq_name_regex: '^[0-9]{6}_A01736_[0-9]{4}_.{10}(?:\+.{8})?$'
 
-outfolder_regex: '^[A-Z0-9]+\d{6,7}_\d{6}_[A-Z0-9]{10}_\d{6}-\d{6}$'
-
 previous_runs_file_path: '../runlists/novaseq_runlist.txt'
 wrapper_log_path: '/clinical/exec/wgs_somatic/logs'
 

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -155,6 +155,11 @@ def copy_results(outputdir, tumorname=None, normalname=None):
                             logger(f"Skipping copy of {src_path} as it is a .cram or .crai file.")
                             continue
 
+                        # Do not copy wgsadmin qc stats file
+                        if src_path.endswith('_qc_stats_wgsadmin.xlsx'):
+                            logger(f"Skipping copy of {src_path} as it is a wgsadmin qc stats file.")
+                            continue
+
                         copyfile(src_path, dest_path)
                         logger(f"Copied {src_path} to {dest_path}")
 

--- a/tools/wgs_admin_summary/combine_wgsadmin_qc_summary.py
+++ b/tools/wgs_admin_summary/combine_wgsadmin_qc_summary.py
@@ -108,7 +108,7 @@ def cli(launcher_config, outputdirs, runname, qc_summary_directory):
     """
     Combine the first *_qc_stats_wgsadmin.xlsx file found in each output directory into a single summary Excel and TSV file.
 
-    For each output directory, searches for qc_report/*_qc_stats_wgsadmin.xlsx, or if not found, */*_qc_stats_wgsadmin.xlsx.
+    For each output directory, searches for qc_report/*_qc_stats_wgsadmin.xlsx, or elsewhere if not found.
     Reads the first matching file into a DataFrame and combines all found DataFrames into a single summary file.
     Output files are written to the specified QC summary directory, the launcher config's wgsadmin_dir, or the current directory.
     """

--- a/tools/wgs_admin_summary/combine_wgsadmin_qc_summary.py
+++ b/tools/wgs_admin_summary/combine_wgsadmin_qc_summary.py
@@ -4,7 +4,9 @@ import click
 import json
 import logging
 from collections import defaultdict
-import re
+import glob
+from launch_snakemake import get_timestamp
+
 
 def setup_logging(log_dir):
     os.makedirs(log_dir, exist_ok=True)
@@ -17,137 +19,100 @@ def setup_logging(log_dir):
         ]
     )
 
-def combine_qc_stats(launcher_config, runtag_results, base_directory=None, output_directory=None, logger=None,regex=None):
+
+def collect_wgsadmin_qc(outputdirs, logger):
     """
-    Command-line tool to combine '_qc_stats_wgsadmin.xlsx' files for each runtag in the given BASE_DIRECTORY.
+    For each outputdir, find the first *_qc_stats_wgsadmin.xlsx in qc_report or subdirs,
+    read into a DataFrame, and return a dict: {outputdir: df or None}
     """
-    # Load launcher_config once and parse it
-    try:
-        with open(launcher_config, 'r') as launcher_config_file:
-            config_data = json.load(launcher_config_file)
-    except (FileNotFoundError, json.JSONDecodeError) as e:
-        raise FileNotFoundError(f"Launcher config not found or invalid: {e}")
-    
+    qc_data = {}
+    for outputdir in outputdirs:
+        if not os.path.exists(outputdir):
+            logger.warning(f"Output directory does not exist: {outputdir}. Skipping...")
+            continue
+        found_files = glob.glob(os.path.join(outputdir, "qc_report", "*_qc_stats_wgsadmin.xlsx"))
+        if not found_files:
+            logger.info(f"No qc_report directory or no matching files in {outputdir}. Searching all subdirectories...")
+            found_files = glob.glob(os.path.join(outputdir, "*", "*_qc_stats_wgsadmin.xlsx"))
+            if not found_files:
+                logger.warning(f"No matching files found in any subdirectory of {outputdir}. Skipping...")
+                continue
+        logger.info(f"Found qc_admin file(s) in {outputdir}: {found_files}")
+        if len(found_files) > 1:
+            logger.warning(f"Multiple qc_admin files found in {outputdir}. Only {found_files[0]} will be processed.")
+        try:
+            df = pd.read_excel(found_files[0])
+            qc_data[outputdir] = df
+        except Exception as e:
+            logger.error(f"Error reading {found_files[0]}: {e}")
+            qc_data[outputdir] = None
+    return qc_data
+
+
+def combine_qc_stats(launcher_config, outputdirs, runname=None, qc_summary_directory=None, logger=None):
+    """
+    Combine the first *_qc_stats_wgsadmin.xlsx file found in each output directory into a single summary Excel and TSV file.
+    """
+    config_data = {}
+    if launcher_config:
+        try:
+            with open(launcher_config, 'r') as launcher_config_file:
+                config_data = json.load(launcher_config_file)
+        except (FileNotFoundError, json.JSONDecodeError) as e:
+            raise FileNotFoundError(f"Launcher config not found or invalid: {e}")
+
     if not logger:
-        setup_logging(config_data.get('logdir'))
+        logdir = config_data.get('logdir', os.getcwd())
+        setup_logging(logdir)
         logger = logging.getLogger(__name__)
-    
+
     logger.info("Starting WGS admin QC summary per run")
-    
-    # If output_directory is not provided, read it from the launcher_config
-    # If base_directory is not provided, read it from the launcher_config
-    try:
-        if output_directory is None:
-            output_directory = config_data.get('wgsadmin_dir')
-            if output_directory is None:
-                raise KeyError("Key 'wgsadmin_dir' not found in launcher_config.")
-        if base_directory is None:
-            base_directory = config_data.get('resultdir_hg38')
-            if base_directory is None:
-                raise KeyError("Key 'resultdir_hg38' not found in launcher_config.")
-    except KeyError as e:
-        raise FileNotFoundError(f"Launcher config missing required key: {e}")
-        
-    logger.info(f"Base directory: {base_directory}")
-    logger.info(f"Output directory: {output_directory}")
-    
-    # Dictionary to store dataframes for each runtag
-    runtag_dataframes = defaultdict(list)
 
-    if runtag_results:
-        runtag_parts = runtag_results.split("+")[0].split("_")
-        input_runtag = f"{runtag_parts[0]}_{runtag_parts[3]}"
+    # Prepare output directories and files
+    if qc_summary_directory is None:
+        qc_summary_directory = config_data.get('wgsadmin_dir', os.getcwd())
+    if runname:
+        outputfile_prefix = os.path.join(qc_summary_directory, f"{runname}_wgs_somatic_qc_summary_{get_timestamp()}")
     else:
-        input_runtag = None
+        outputfile_prefix = os.path.join(qc_summary_directory, f"wgs_somatic_qc_summary_{get_timestamp()}")
+    output_file_xlsx = f"{outputfile_prefix}.xlsx"
+    output_file_tsv = f"{outputfile_prefix}.tsv"
+    if os.path.exists(output_file_xlsx) or os.path.exists(output_file_tsv):
+        raise FileExistsError(f"Output file(s) already exist: {output_file_xlsx} or {output_file_tsv}")
+    logger.info(f"QC summary directory: {qc_summary_directory}")
+    os.makedirs(qc_summary_directory, exist_ok=True)
+    logger.info(f"Output files will be: {output_file_xlsx} and {output_file_tsv}")
 
-    # Walk through all subdirectories in the base directory
-    for root, dirs, files in os.walk(base_directory):
-        # Extract the runtag (second and third parts of the current directory name)
-        parent_dir = os.path.basename(root)
-        if regex and re.match(regex, parent_dir):
-            parts = parent_dir.split('_')
-            current_runtag = f"{parts[1]}_{parts[2]}"
-            # If a specific runtag is provided, skip directories that don't match exactly
-            if input_runtag and current_runtag != input_runtag:
-                # logger.info(f"Skipping directory: {root} as it does not match the specified runtag: {input_runtag}")
-                continue
+    # Collect QC data from each outputdir
+    qc_data = collect_wgsadmin_qc(outputdirs, logger)
 
-            logger.info(f"Processing directory: {root} for runtag: {current_runtag}")
-
-            # Find all matching files in the current directory
-            matching_files = [file for file in files if file.endswith("_qc_stats_wgsadmin.xlsx")]
-
-            # Skip the directory if no matching files are found
-            if not matching_files:
-                logger.warning(f"No '_qc_stats_wgsadmin.xlsx' files found in {root}. Skipping...")
-                continue
-
-            # Process each matching file
-            for file in matching_files:
-                file_path = os.path.join(root, file)
-                try:
-                    df = pd.read_excel(file_path)
-                    runtag_dataframes[current_runtag].append((file_path, df))
-                    logger.info(f"Successfully read file: {file_path}")
-                except Exception as e:
-                    logger.error(f"Error reading {file_path}: {e}")
-
-    if not runtag_dataframes:
-        raise RuntimeError(f"No QC summary files found for runtag {input_runtag}")
-    
-    os.makedirs(output_directory, exist_ok=True)
-
-    # Combine and save the dataframes for each runtag
-    for runtag, file_dataframes in runtag_dataframes.items():
-        logger.info(f"Processing runtag: {runtag} with {len(file_dataframes)} files")
-        
-        output_file_xlsx = os.path.join(output_directory, f"{runtag}_wgs_somatic_qc_summary.xlsx")
-        output_file_tsv = os.path.join(output_directory, f"{runtag}_wgs_somatic_qc_summary.tsv")
-        
-        if os.path.exists(output_file_xlsx):
-            logger.info(f"Existing combined file found for runtag {runtag}: {output_file_xlsx}")
-            # Read the existing combined file
-            existing_df = pd.read_excel(output_file_xlsx)
-            combined_df = existing_df
-            # newer_file_detected = False
-            new_content_detected = False
-            for file_path, new_df in file_dataframes:
-                # check if the content of the files in the directory is already in the combined file
-                if not new_df.isin(existing_df.to_dict(orient='list')).all().all():
-                    logger.info(f"New content detected in file: {file_path}. Combining with existing summary.")
-                    combined_df = pd.concat([combined_df, new_df], ignore_index=True).drop_duplicates()
-                    new_content_detected = True
-                else:
-                    logger.info(f"Skipping {file_path} as its content is already present in the existing combined file.")
-            
-            if not new_content_detected:
-                logger.info(f"No new content detected for runtag {runtag}. Skipping...")
-                continue
-        else:
-            logger.info(f"No existing combined file found for runtag {runtag}. Creating a new one.")
-            # Combine all new dataframes if no existing file
-            combined_df = pd.concat([df for _, df in file_dataframes], ignore_index=True).drop_duplicates()
-        
-        # Save the combined file
-        combined_df.to_excel(output_file_xlsx, index=False)
-        combined_df.to_csv(output_file_tsv, sep='\t', index=False)
-        logger.info(f"Combined files saved for runtag {runtag}: {output_file_xlsx} and {output_file_tsv}")
-
-    logger.info("Finished WGS admin QC summary summary per run.")
+    # Combine all DataFrames into one and save
+    if not qc_data:
+        logger.warning("No QC data collected from any output directories.")
+        return
+    combined_df = pd.concat(qc_data.values(), ignore_index=True)
+    combined_df.to_excel(output_file_xlsx, index=False)
+    combined_df.to_csv(output_file_tsv, sep='\t', index=False)
+    logger.info(f"Combined QC summary saved to {output_file_xlsx} and {output_file_tsv}")
 
 @click.command()
-@click.option('--launcher_config', required=True, help='Path to launcher config JSON file.')
-@click.option('--runtag_results', required=False, help='Runtag of the directories to process.')
-@click.option('--base_directory', required=False, help='Base directory to search for QC files.')
-@click.option('--output_directory', required=False, help='Directory to save combined summary files.')
-@click.option('--regex', required=False, help='Regex to match directory names.')
-def cli(launcher_config, runtag_results, base_directory, output_directory, regex):
+@click.option('--launcher-config', required=False, help='Path to launcher config JSON file (optional).')
+@click.option('--outputdirs', required=True, multiple=True, help='List of output directories to search for QC files. Can be specified multiple times.')
+@click.option('--runname', required=False, help='Optional run name for output file naming.')
+@click.option('--qc-summary-directory', required=False, help='Directory to save combined summary files. If not set, uses wgsadmin_dir from launcher config or current directory.')
+def cli(launcher_config, outputdirs, runname, qc_summary_directory):
+    """
+    Combine the first *_qc_stats_wgsadmin.xlsx file found in each output directory into a single summary Excel and TSV file.
+
+    For each output directory, searches for qc_report/*_qc_stats_wgsadmin.xlsx, or if not found, */*_qc_stats_wgsadmin.xlsx.
+    Reads the first matching file into a DataFrame and combines all found DataFrames into a single summary file.
+    Output files are written to the specified QC summary directory, the launcher config's wgsadmin_dir, or the current directory.
+    """
     combine_qc_stats(
         launcher_config=launcher_config,
-        runtag_results=runtag_results,
-        base_directory=base_directory,
-        output_directory=output_directory,
-        regex=regex
+        outputdirs=outputdirs,
+        runname=runname,
+        qc_summary_directory=qc_summary_directory
     )
 
 if __name__ == "__main__":

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -319,7 +319,7 @@ def wrapper(instrument=None, outpath=None):
         # and don't need to be added as arguments
         try:
             logger.info(f'Combining qc stats for run {Rctx_run.run_name}')
-            combine_qc_stats(launcher_config = LAUNCHER_CONFIG_PATH, runtag_results=Rctx_run.run_name, logger=logger, regex=config['outfolder_regex'])
+            combine_qc_stats(launcher_config = LAUNCHER_CONFIG_PATH, outputdirs=outputdirs, runname=Rctx_run.run_name, logger=logger)
             logger.info(f'Done with combining qc stats for run {Rctx_run.run_name}')
         except Exception as e:
             logger.error(f"Error combining qc stats: {e}")

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -367,11 +367,11 @@ def manual(tumorsample=None, normalsample=None, outpath=None, copyresults=False,
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('-i', '--instrument', help='For example novaseq_687_gc or novaseq_A01736', required=False)
-    parser.add_argument('--tumorsample', help='Specify the name of the tumor sample (e.g. DNA123456)', required=False)
-    parser.add_argument('--normalsample', help='Specify the name of the normal sample (e.g. DNA123456)', required=False)
+    parser.add_argument('-t','--tumorsample', help='Specify the name of the tumor sample (e.g. DNA123456)', required=False)
+    parser.add_argument('-n','--normalsample', help='Specify the name of the normal sample (e.g. DNA123456)', required=False)
     parser.add_argument('-o', '--outpath', help='Manually specify the path where the outputdir will go', required=False)
-    parser.add_argument('-cr', '--copyresults', help='Copy the results from a manual run to webstore', required=False, action='store_true', default=False)
-    parser.add_argument('-qc', '--qcsummary', help='Create combined qc summary for the run', required=False, action='store_true', default=False)
+    parser.add_argument('-c', '--copyresults', help='Copy the results from a manual run to webstore', required=False, action='store_true', default=False)
+    parser.add_argument('-q', '--qcsummary', help='Create combined qc summary for the run', required=False, action='store_true', default=False)
     args = parser.parse_args()
 
     if args.instrument:

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -331,7 +331,7 @@ def wrapper(instrument=None, outpath=None):
     # only considers barncancer hg38 (GMS-AL + GMS-BT samples) right now.
 
 
-def manual(tumorsample=None, normalsample=None, outpath=None, copyresults=False):
+def manual(tumorsample=None, normalsample=None, outpath=None, copyresults=False, qcsummary=False):
     '''Manual pipeline submission'''
     config = read_config(WRAPPER_CONFIG_PATH)
     wrapper_log_path = config["wrapper_log_path"]
@@ -353,6 +353,14 @@ def manual(tumorsample=None, normalsample=None, outpath=None, copyresults=False)
 
     if copyresults and check_ok(outputdir):
         copy_results(outputdir)
+
+    if qcsummary and check_ok(outputdir):
+        try:
+            logger.info(f'Combining qc stats for manual run with outputdir {outputdir}')
+            combine_qc_stats(launcher_config = LAUNCHER_CONFIG_PATH, outputdirs=[outputdir], runname='manual_run', logger=logger)
+            logger.info(f'Done with combining qc stats for manual run with outputdir {outputdir}')
+        except Exception as e:
+            logger.error(f"Error combining qc stats: {e}")
     return
 
 
@@ -363,6 +371,7 @@ def main():
     parser.add_argument('--normalsample', help='Specify the name of the normal sample (e.g. DNA123456)', required=False)
     parser.add_argument('-o', '--outpath', help='Manually specify the path where the outputdir will go', required=False)
     parser.add_argument('-cr', '--copyresults', help='Copy the results from a manual run to webstore', required=False, action='store_true', default=False)
+    parser.add_argument('-qc', '--qcsummary', help='Create combined qc summary for the run', required=False, action='store_true', default=False)
     args = parser.parse_args()
 
     if args.instrument:
@@ -370,7 +379,7 @@ def main():
             parser.warning("When specifying --instrument, --tumorsample, --normalsample and --copyresults are ignored.")
         wrapper(args.instrument, args.outpath)
     elif args.tumorsample or args.normalsample:
-        manual(args.tumorsample, args.normalsample, args.outpath, args.copyresults)
+        manual(args.tumorsample, args.normalsample, args.outpath, args.copyresults, args.qcsummary)
     else:
         parser.error("You must specify either --instrument or --tumorsample/--normalsample.")
 


### PR DESCRIPTION
### The What

- Run qc-summary on workdirectories (outputdirs) from the wrapper directly
- Add option to run qc-summary with manual wrapper run
- Modify option to run qc-summary on list of outputdirs (for standalone runs)
- Update README to explain how to run the qc-summary
- No longer copy the wgsadmin_qc_stats for each run to webstore

### The Why

- Previously, running qc-summary by looking through webstore caused problems (see issue #112)
- Now should be easier to run qc-summary with manual wrapper run or on list of outputdirs

### The How

- Mostly changes to `combine_wgsadmin_qc_summary.py`
- Changes to wrapper to work with the new `combine_wgsadmin_qc_summary.py` and support manual runs
- For running the standalone module:

```
Usage: python -m tools.wgs_admin_summary.combine_wgsadmin_qc_summary 
           [OPTIONS]

  Combine the first *_qc_stats_wgsadmin.xlsx file found in each output
  directory into a single summary Excel and TSV file.

  For each output directory, searches for qc_report/*_qc_stats_wgsadmin.xlsx,
  or elsewhere if not found. Reads the first matching file into a DataFrame
  and combines all found DataFrames into a single summary file. Output files
  are written to the specified QC summary directory, the launcher config's
  wgsadmin_dir, or the current directory.

Options:
  --launcher-config FILE          Path to launcher config JSON file
                                  (optional).
  -o, --outputdirs DIRECTORY      List of output directories to search for QC
                                  files. Can be specified multiple times.
                                  [required]
  --runname TEXT                  Optional run name for output file naming.
  --qc-summary-directory DIRECTORY
                                  Directory to save combined summary files. If
                                  not set, uses wgsadmin_dir from launcher
                                  config or current directory.
  --help                          Show this message and exit.
```

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [X] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions


### Tests
- Manual tumor-normal wrapper run
- Ran module on list of outputdirs
