### PR TITLE
Fix new ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,9 +93,7 @@ python launch_snakemake.py \
     ```{bash}
     python launch_snakemake.py \
       --outputdir <Same directory as specified when running the pipeline> \
-      --onlycopyresults \
-      --tumorsample <[Optional] e.g. "DNA654321" to match config with resultdir path> \
-      --normalsample <[Optional] If neither tumorsample or normalsample are given, will match with DNA*_config.json>
+      --onlycopyresults
     ```
 
 ### Dependencies

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -94,40 +94,20 @@ def yearly_stats(tumorname, normalname):
         )
 
 
-def copy_results(outputdir, tumorname=None, normalname=None):
+def copy_results(outputdir):
     """Rsync result files from outputdir to resultdir"""
     try:
         # Automatic detection of runconfig
-        config_dir = os.path.join(outputdir, "configs")
-        if tumorname:
-            config_pattern = re.compile(rf"^{tumorname}.*_config\.json$")
-        elif normalname:
-            config_pattern = re.compile(rf"^{normalname}.*_config\.json$")
-        else:
-            # Fallback to a generic pattern if no specific names are provided
-            config_pattern = re.compile(r"^DNA[\dA-Za-z]+_.+_.+_config\.json$")
+        snakemake_config = os.path.join(outputdir, "configs", "snakemake_config.json")
 
-        if os.path.isdir(config_dir):
-            for f in os.listdir(config_dir):
-                if config_pattern.match(f):
-                    runconfig = os.path.join(config_dir, f)
-                    logger(f"Found runconfig: {runconfig}")
-                    break
-            else:
-                logger(
-                    f"Automatic detection of config file failed. No matching configuration file found in {config_dir}"
-                )
-                logger(
-                    f"Pattern used to match the config file: {config_pattern.pattern}"
-                )
-                raise ValueError(
-                    "Automatic detection of config file failed. No matching configuration file found."
-                )
+        if not os.path.isfile(snakemake_config):
+            logger(f"Config file not found at expected location: {snakemake_config}")
+            raise FileNotFoundError(f"Config file not found at expected location: {snakemake_config}")
 
         try:
             # Read the runconfig file to get resultdir and resultsconf
-            with open(runconfig, "r") as cf:
-                config_data = json.load(cf)
+            with open(snakemake_config, "r") as sc:
+                config_data = json.load(sc)
                 try:
                     resultdir = config_data.get("resultdir")
                     logger(f"Resultdir found in config file: {resultdir}")
@@ -377,10 +357,9 @@ def analysis_main(args, outputdir, normalname=False, normalfastqs=False, tumorna
                 analysisdict["resultdir"] = f'{config["resultdir_hg38"]}/{basename_outputdir}'
             else:
                 analysisdict["resultdir"] = f'{config["resultdir_hg38"]}/tumor_only/{basename_outputdir}'
-            snakemake_config = f"{runconfigs}/{tumorid}_config.json"
         else:
             analysisdict["resultdir"] = f'{config["resultdir_hg38"]}/normal_only/{basename_outputdir}'
-            snakemake_config = f"{runconfigs}/{normalid}_config.json"
+        snakemake_config = f"{runconfigs}/snakemake_config.json"
 
         with open(snakemake_config, 'w') as analysisconf:
             json.dump(analysisdict, analysisconf, ensure_ascii=False, indent=4)
@@ -495,7 +474,7 @@ if __name__ == '__main__':
         args.outputdir = os.path.abspath(args.outputdir)
         logger(f"Adjusted outputdir to {args.outputdir}")
     if args.onlycopyresults:
-        copy_results(args.outputdir, args.tumorsample, args.normalsample)
+        copy_results(args.outputdir)
     else:
         if args.tumorfastqs:
             if not args.tumorfastqs.startswith("/"):
@@ -512,12 +491,12 @@ if __name__ == '__main__':
                 # these functions are only executed if snakemake workflow has finished successfully
                 yearly_stats(args.tumorsample, args.normalsample)
                 if args.copyresults:
-                    copy_results(args.outputdir, args.tumorsample, args.normalsample)
+                    copy_results(args.outputdir)
             else:
                 yearly_stats(args.tumorsample, 'None')
                 if args.copyresults:
-                    copy_results(args.outputdir, args.tumorsample, None)
+                    copy_results(args.outputdir)
         else:
             yearly_stats('None', args.normalsample)
             if args.copyresults:
-                copy_results(args.outputdir, None, args.normalsample)
+                copy_results(args.outputdir)

--- a/tools/slims.py
+++ b/tools/slims.py
@@ -381,11 +381,6 @@ def get_pair_dict(Sctx, Rctx, logger):
                               .add(equals('cntn_cstm_tumorNormalID', 
                               Sctx.slims_info['tumorNormalID'])))
 
-    # If they don't have the same tumorNormalID
-    pairs2 = slims_connection.fetch('Content', conjunction()
-                              .add(equals('cntn_fk_contentType', 6))
-                              .add(equals('cntn_id','DNA'+Sctx.slims_info['tumorNormalID'])))
-    
     # We want to make sure that we complement the tumorNormalType correctly, i.e. a tumor goes with normal and vice versa
     pair_type_d = {'tumor':'normal', 'normal':'tumor'}
     pair_type = pair_type_d.get(Sctx.slims_info['tumorNormalType'],None)
@@ -399,13 +394,5 @@ def get_pair_dict(Sctx, Rctx, logger):
                 pair_slims_sample['tumorNormalType'] == pair_type:
             pair_dict[pair_slims_sample['content_id']] = [pair_slims_sample['tumorNormalType'], pair_slims_sample['tumorNormalID'], pair_slims_sample['department'], pair_slims_sample['is_priority']]
             # Check if there are additional fastqs in other runs and symlink fastqs
-    for p in pairs2:
-        pair_slims_sample = translate_slims_info(p)
-        if not pair_slims_sample['tumorNormalType'] == pair_type:
-            continue
-        if not pair_slims_sample['content_id'] in pair_dict:
-            logger.info(f'Using sample {pair_slims_sample["content_id"]} as a pair to {Sctx.slims_info["content_id"]} (tumorNormalID {Sctx.slims_info["tumorNormalID"]}), but it does not have a matching tumorNormalID')
-        if not pair_slims_sample['tumorNormalType']:
-            logger.warning(f'The sample {pair_slims_sample["content_id"]} does not have any assigned tumorNormalType, will not be used in pairing')
-        pair_dict[pair_slims_sample['content_id']] = [pair_slims_sample['tumorNormalType'], pair_slims_sample['tumorNormalID'], pair_slims_sample['department'], pair_slims_sample['is_priority']]
+
     return pair_dict

--- a/tools/slims.py
+++ b/tools/slims.py
@@ -393,6 +393,5 @@ def get_pair_dict(Sctx, Rctx, logger):
         if pair_slims_sample['content_id'] == Sctx.slims_info['content_id'] or\
                 pair_slims_sample['tumorNormalType'] == pair_type:
             pair_dict[pair_slims_sample['content_id']] = [pair_slims_sample['tumorNormalType'], pair_slims_sample['tumorNormalID'], pair_slims_sample['department'], pair_slims_sample['is_priority']]
-            # Check if there are additional fastqs in other runs and symlink fastqs
 
     return pair_dict

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -252,7 +252,7 @@ def wrapper(instrument=None, outpath=None):
             paired = False
             for n_key, n_value in normal_samples.items():
                 n_ID = n_value[1]  # tumorNormalID
-                if t_ID == n_ID or t_ID == n_key.split("DNA")[1] or n_ID == t_key.split("DNA")[1]:
+                if t_ID == n_ID:
                     paired_samples.append((t_key, n_key))
                     paired = True
                     outputdir = submit_pipeline(t_key, n_key, outpath, config, logger, threads)


### PR DESCRIPTION
### The What

Fix for new IDs which will no longer use `DNA123456`. I do not expect any hard errors but some fallback logic will no longer work. If we need to pair with an old sample which lacks a `tumornormalID` the lab will need to notify us. 

- Removed fallback logic with `DNA`+`tumornormalID`
- Renamed `snakemake config` from `tumorid`_config.json to snakemake_config.json so we can always find it.

### This [update](https://semver.org/) is:
- [ ] **MAJOR** - when you make incompatible API changes
- [X] **MINOR** - when you add functionality in a backwards compatible manner
- [ ] **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

### Tests
Tested tumor-normal manual run (from slims)