### PR TITLE
Feature/dev mode

### DIFF
--- a/configs/launcher_config.json
+++ b/configs/launcher_config.json
@@ -10,5 +10,7 @@
     "resultfilesconf": "result_files_config.yaml",
     "resultdir_hg38": "/webstore/clinical/routine/wgs_somatic/current",
     "webstore_api_url": "http://webstore.sa.gu.se/api/paths",
-    "wgsadmin_dir": "/webstore/clinical/routine/laboratory/current/quality_reports/"
+    "wgsadmin_dir": "/webstore/clinical/routine/laboratory/current/quality_reports/",
+    "resultdir_dev": "/clinical/dev/cgg-cancer/wgs_somatic/dev_run/webstore/data",
+    "wgsadmin_dev": "/clinical/dev/cgg-cancer/wgs_somatic/dev_run/webstore/quality_reports/"
 }

--- a/configs/wrapper_config.yaml
+++ b/configs/wrapper_config.yaml
@@ -48,10 +48,10 @@ slims_credentials_path: '/clinical/exec/wgs_somatic/dependencies/credentials/sli
 email_config_path: '/clinical/exec/wgs_somatic/dependencies/configs/mail_config.yaml'
 
 develop_mode:
-  outpath: '/clinical/dev/cgg-cancer/wgs_somatic/data/' 
-  runpath: '/clinical/dev/cgg-cancer/wgs_somatic/810806_A000000_0000_FL00OWCELL+1a2b3c4d'
-  log_path: '/clinical/dev/cgg-cancer/wgs_somatic/logs/'
-  email_config_path: '/clinical/dev/cgg-cancer/wgs_somatic/dependencies/configs/mail_config.yaml'
+  outpath: '/clinical/dev/cgg-cancer/wgs_somatic/dev_run/data/' 
+  runpath: '/clinical/dev/cgg-cancer/wgs_somatic/dev_run/810806_A000000_0000_FL00OWCELL+1a2b3c4d'
+  log_path: '/clinical/dev/cgg-cancer/wgs_somatic/dev_runlogs/'
+  email_config_path: '/clinical/dev/cgg-cancer/wgs_somatic/dev_run/dependencies/configs/mail_config.yaml'
   success:
     samples:
       - sample: 'DNA96714_221028_BH2CGFDSX5'

--- a/configs/wrapper_config.yaml
+++ b/configs/wrapper_config.yaml
@@ -21,8 +21,6 @@ cron_outpath: '/clinical/data/wgs_somatic/cron'
 
 manual_outpath: '/clinical/data/wgs_somatic/manual/'
 
-development_outpath: '/clinical/data/wgs_somatic/development/' 
-
 hcp_download_dir: '/clinical/data/wgs_somatic/hcp_downloads'
 
 hcp:
@@ -47,5 +45,19 @@ hcp:
 
 slims_credentials_path: '/clinical/exec/wgs_somatic/dependencies/credentials/slims_credentials.yaml'
 
-email_config_path: '/clinical/exec/wgs_somatic/dependencies/credentials/mail_config.yaml'
+email_config_path: '/clinical/exec/wgs_somatic/dependencies/configs/mail_config.yaml'
+
+develop_mode:
+  outpath: '/clinical/dev/cgg-cancer/wgs_somatic/data/' 
+  runpath: '/clinical/dev/cgg-cancer/wgs_somatic/810806_A000000_0000_FL00OWCELL+1a2b3c4d'
+  log_path: '/clinical/dev/cgg-cancer/wgs_somatic/logs/'
+  email_config_path: '/clinical/dev/cgg-cancer/wgs_somatic/dependencies/configs/mail_config.yaml'
+  fail:
+    samples:
+      - sample: 'DNA96714_221028_BH2CGFDSX5'
+        type: 'normal'
+        fastq_paths: ['/clinical/data/wgs_somatic/testfiles/221028_BH2CGFDSX5/DNA96714_221028_BH2CGFDSX5_S15_R1_001.fastq.gz', '/clinical/data/wgs_somatic/testfiles/221028_BH2CGFDSX5/DNA96714_221028_BH2CGFDSX5_S15_R2_001.fastq.gz']
+      - sample: 'DNA97155_221104_AH3L7JDSX5'
+        type: 'tumor' 
+        fastq_paths: ['/clinical/data/wgs_somatic/testfiles/221104_AH3L7JDSX5/DNA97155_221104_AH3L7JDSX5_S4_R1_001.fastq.gz', '/clinical/data/wgs_somatic/testfiles/221104_AH3L7JDSX5/DNA97155_221104_AH3L7JDSX5_S4_R1_001.fastq.gz']
 

--- a/configs/wrapper_config.yaml
+++ b/configs/wrapper_config.yaml
@@ -52,7 +52,7 @@ develop_mode:
   runpath: '/clinical/dev/cgg-cancer/wgs_somatic/810806_A000000_0000_FL00OWCELL+1a2b3c4d'
   log_path: '/clinical/dev/cgg-cancer/wgs_somatic/logs/'
   email_config_path: '/clinical/dev/cgg-cancer/wgs_somatic/dependencies/configs/mail_config.yaml'
-  fail:
+  success:
     samples:
       - sample: 'DNA96714_221028_BH2CGFDSX5'
         type: 'normal'
@@ -60,4 +60,3 @@ develop_mode:
       - sample: 'DNA97155_221104_AH3L7JDSX5'
         type: 'tumor' 
         fastq_paths: ['/clinical/data/wgs_somatic/testfiles/221104_AH3L7JDSX5/DNA97155_221104_AH3L7JDSX5_S4_R1_001.fastq.gz', '/clinical/data/wgs_somatic/testfiles/221104_AH3L7JDSX5/DNA97155_221104_AH3L7JDSX5_S4_R1_001.fastq.gz']
-

--- a/configs/wrapper_config.yaml
+++ b/configs/wrapper_config.yaml
@@ -21,6 +21,8 @@ cron_outpath: '/clinical/data/wgs_somatic/cron'
 
 manual_outpath: '/clinical/data/wgs_somatic/manual/'
 
+development_outpath: '/clinical/data/wgs_somatic/development/' 
+
 hcp_download_dir: '/clinical/data/wgs_somatic/hcp_downloads'
 
 hcp:
@@ -44,3 +46,6 @@ hcp:
   retries: 20
 
 slims_credentials_path: '/clinical/exec/wgs_somatic/dependencies/credentials/slims_credentials.yaml'
+
+email_config_path: '/clinical/exec/wgs_somatic/dependencies/credentials/mail_config.yaml'
+

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -393,6 +393,7 @@ def analysis_main(
         logger(f"{e} Traceback: {tb}")
         sys.exit(1)
 
+
     try:
         ###################################################################
         # Start SnakeMake pipeline

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -189,6 +189,7 @@ def analysis_main(
     notemp=False,
     dag=False,
 ):
+    devmode = os.environ.get("DEVMODE") == "true"
     try:
         ################################################################
         # Write InputArgs to logfile
@@ -382,6 +383,12 @@ def analysis_main(
             analysisdict["resultdir"] = (
                 f"{config['resultdir_hg38']}/normal_only/{basename_outputdir}"
             )
+        # Override result directory in development mode
+        if devmode:
+            analysisdict["resultdir"] = (
+                f"{config['resultdir_dev']}/{basename_outputdir}"
+                    )
+
         snakemake_config = f"{runconfigs}/snakemake_config.json"
 
         with open(snakemake_config, "w") as analysisconf:

--- a/launch_snakemake.py
+++ b/launch_snakemake.py
@@ -581,8 +581,18 @@ if __name__ == "__main__":
         help="Also generate a separate DAG svg in logs",
         required=False,
     )
+    parser.add_argument(
+            '-d',
+            '--develop_mode',
+            help='launch "launch_snakemake" in "develop mode',
+            required=False,
+            action='store_true',
+            default=False,
+    )
     args = parser.parse_args()
-
+    
+    if args.develop_mode:
+        os.environ["DEVMODE"] = "true"
     if not args.outputdir.startswith("/"):
         args.outputdir = os.path.abspath(args.outputdir)
         logger(f"Adjusted outputdir to {args.outputdir}")

--- a/tools/custom_email.py
+++ b/tools/custom_email.py
@@ -4,13 +4,15 @@ import smtplib
 from definitions import WRAPPER_CONFIG_PATH
 from tools.helpers import read_config
 from email.message import EmailMessage
+from textwrap import dedent, indent
 
 config = read_config(WRAPPER_CONFIG_PATH)
 email_config_path = config['email_config_path']
 email_config = read_config(email_config_path)
 smtp = email_config["smtp_server"]
-sender = email_config["sender"]
-mode = "development" if develop else "default" #TODO add develop, right now it defaults to default
+#mode = "development" if develop else "default" #TODO add develop, right now it defaults to default
+mode = "default"
+sender = email_config[mode]["sender"]
 success_recipients = ", ".join(email_config[mode]["recipients"])
 qc_recipients = ", ".join(email_config[mode]["qc"])
 
@@ -53,12 +55,18 @@ def start_email(run_name, samples):
 
     subject = f"WGS Somatic start mail {run_name}"
 
-    body = f"""Starting wgs_somatic for the following samples in run {run_name}:\n
-{"\n".join(samples)}\n
-You will get an email when the results are ready.\n
+    sample_list = "\n".join(samples)
+    body = f"""\
+Starting wgs_somatic for the following samples in run
+{run_name}:
+
+{sample_list}
+
+You will get an email when the results are ready.
+
 Best regards,
 CGG Cancer
- """
+"""
 
     send_email(subject, body)
 
@@ -68,8 +76,12 @@ def end_email(run_name, samples):
 
     subject = f"WGS Somatic end mail {run_name}"
 
-    body = f"""WGS somatic has finished successfully for the following samples in run {run_name}:\n
-{"\n".join(samples)}\n
+    sample_list = "\n".join(samples)
+    body = f"""\
+WGS somatic has finished successfully for the following samples in run {run_name}:
+
+{sample_list}
+
 Best regards,
 CGG Cancer
 """
@@ -82,11 +94,19 @@ def error_email(run_name, ok_samples, bad_samples):
 
     subject = f"Crashed WGS Somatic {run_name}"
 
-    body = f"""WGS somatic failed for the following samples in run {run_name}:\n
-{new_line.join(bad_samples)}\n
-The following samples did finish correctly:\n
-{new_line.join(ok_samples)}\n
-Errors concerning the above samples will be investigated.\n
+    ok_samples_list = "\n".join(ok_samples)
+    bad_samples_list = "\n".join(bad_samples)
+    body = f"""\
+WGS somatic failed for the following samples in run {run_name}:
+
+{bad_samples_list}
+
+The following samples did finish correctly:
+
+{ok_samples_list}
+
+Errors concerning the above samples will be investigated.
+
 Best regards,
 CGG Cancer
 """
@@ -99,11 +119,14 @@ def error_setup_email(instrument):
 
     subject = f"Crashed WGS somatic setup for {instrument}"
 
-    body = f"""The automatic setup of WGS somatic failed for instrument {instrument}.\n
-Errors will be investigated.\n
+    body = f"""\
+The automatic setup of WGS somatic failed for instrument {instrument}.
+
+Errors will be investigated.
+
 Best regards,
 CGG Cancer
-    """
+"""
 
     send_email(subject, body)
 
@@ -113,8 +136,10 @@ def error_admin_qc_email(run_name):
 
     subject = f"WGS somatic - admin QC failed {run_name}"
 
-    body = f"""Generating the WGS Admin QC report failed for run {run_name}.\n
-Please create the report manually.\n
-    """
+    body = f"""\
+Generating the WGS Admin QC report failed for run {run_name}.
+
+Please create the report manually.
+"""
 
     send_email_qc(subject, body)

--- a/tools/custom_email.py
+++ b/tools/custom_email.py
@@ -18,13 +18,13 @@ def set_env():
     sender = email_config['sender']
     success_recipients = ", ".join(email_config["recipients"])
     qc_recipients = ", ".join(email_config["qc"])
-    
+
     return smtp, sender, success_recipients, qc_recipients
 
 
 def send_email(subject, body):
     """Send a simple email."""
-    
+ 
     smtp, sender, success_recipients, qc_recipients = set_env()
     msg = EmailMessage()
     msg.set_content(body)
@@ -95,6 +95,69 @@ CGG Cancer
 """
 
     send_email(subject, body)
+
+def manual_start_email(tumor_sample, normal_sample):
+    """Send an email about starting wgs-somatic for samples in a manual run"""
+
+    if tumor_sample:
+        if normal_sample:
+            message: f"""Paired analysis:
+Tumor: {tumor_sample} against
+Normal: {normal_sample}"""
+        else:
+            message = f"Unpaired analysis of tumor sample: {tumor_sample}"
+    elif normal_sample:
+        message = f"Unpaired analysis of tumor sample: {tumor_sample}"
+
+    subject = f"WGS Somatic start mail"
+
+    body = f"""\
+Manual start of wgs_somatic initiated.
+
+{message}
+
+You will get an email when the results are ready.
+
+Best regards,
+CGG Cancer
+"""
+
+    send_email(subject, body)
+
+
+def manual_end_email(success, tumor_sample, normal_sample):
+    """Send an email about wgs-somatic finished a manual run"""
+
+    if tumor_sample:
+        if normal_sample:
+            analysis = f"paired analysis of {tumor_sample} and {normal_sample}"
+        else:
+            analysis = f"unpaired analysis of tumor sample: {tumor_sample}"
+    elif normal_sample:
+        analysis = f"unpaired analysis of tumor sample: {tumor_sample}"
+
+    if success:
+        body = f"""\
+Manual run of WGS somatic has finished successfully for"
+{analysis}
+
+Best regards,
+CGG Cancer
+"""
+    else:
+        body = f"""\
+Manual run of WGS somatic failed for"
+{analysis}
+
+Errors concerning the above samples will be investigated.
+
+
+Best regards,
+CGG Cancer
+"""
+
+    send_email(subject, body)
+
 
 
 def error_email(run_name, ok_samples, bad_samples):

--- a/tools/custom_email.py
+++ b/tools/custom_email.py
@@ -6,20 +6,26 @@ from tools.helpers import read_config
 from email.message import EmailMessage
 from textwrap import dedent, indent
 
-config = read_config(WRAPPER_CONFIG_PATH)
-email_config_path = config['email_config_path']
-email_config = read_config(email_config_path)
-smtp = email_config["smtp_server"]
-#mode = "development" if develop else "default" #TODO add develop, right now it defaults to default
-mode = "default"
-sender = email_config[mode]["sender"]
-success_recipients = ", ".join(email_config[mode]["recipients"])
-qc_recipients = ", ".join(email_config[mode]["qc"])
+
+def set_env():
+    config = read_config(WRAPPER_CONFIG_PATH)
+    if os.environ.get("DEVMODE") == "true":
+        email_config_path = config['develop_mode']['email_config_path']
+    else:
+        email_config_path = config['email_config_path']
+    email_config = read_config(email_config_path)
+    smtp = email_config['smtp_server']
+    sender = email_config['sender']
+    success_recipients = ", ".join(email_config["recipients"])
+    qc_recipients = ", ".join(email_config["qc"])
+    
+    return smtp, sender, success_recipients, qc_recipients
 
 
 def send_email(subject, body):
     """Send a simple email."""
-
+    
+    smtp, sender, success_recipients, qc_recipients = set_env()
     msg = EmailMessage()
     msg.set_content(body)
 
@@ -36,6 +42,7 @@ def send_email(subject, body):
 def send_email_qc(subject, body):
     """Send a simple email."""
 
+    smtp, sender, success_recipients, qc_recipients = set_env()
     msg = EmailMessage()
     msg.set_content(body)
 
@@ -78,7 +85,8 @@ def end_email(run_name, samples):
 
     sample_list = "\n".join(samples)
     body = f"""\
-WGS somatic has finished successfully for the following samples in run {run_name}:
+WGS somatic has finished successfully for the following samples in run 
+{run_name}:
 
 {sample_list}
 

--- a/tools/custom_email.py
+++ b/tools/custom_email.py
@@ -99,6 +99,8 @@ CGG Cancer
 def manual_start_email(tumor_sample, normal_sample):
     """Send an email about starting wgs-somatic for samples in a manual run"""
 
+    subject = f"WGS Somatic start mail"
+
     if tumor_sample:
         if normal_sample:
             message: f"""Paired analysis:
@@ -108,8 +110,6 @@ Normal: {normal_sample}"""
             message = f"Unpaired analysis of tumor sample: {tumor_sample}"
     elif normal_sample:
         message = f"Unpaired analysis of tumor sample: {tumor_sample}"
-
-    subject = f"WGS Somatic start mail"
 
     body = f"""\
 Manual start of wgs_somatic initiated.
@@ -128,6 +128,8 @@ CGG Cancer
 def manual_end_email(success, tumor_sample, normal_sample):
     """Send an email about wgs-somatic finished a manual run"""
 
+    subject = f"WGS Somatic manual end mail"
+    
     if tumor_sample:
         if normal_sample:
             analysis = f"paired analysis of {tumor_sample} and {normal_sample}"

--- a/tools/custom_email.py
+++ b/tools/custom_email.py
@@ -1,9 +1,18 @@
 import os
 import smtplib
 
+from definitions import WRAPPER_CONFIG_PATH
+from tools.helpers import read_config
 from email.message import EmailMessage
 
-new_line = "\n"
+config = read_config(WRAPPER_CONFIG_PATH)
+email_config_path = config['email_config_path']
+email_config = read_config(email_config_path)
+smtp = email_config["smtp_server"]
+sender = email_config["sender"]
+mode = "development" if develop else "default" #TODO add develop, right now it defaults to default
+success_recipients = ", ".join(email_config[mode]["recipients"])
+qc_recipients = ", ".join(email_config[mode]["qc"])
 
 
 def send_email(subject, body):
@@ -13,17 +22,14 @@ def send_email(subject, body):
     msg.set_content(body)
 
     msg["Subject"] = subject
-    msg["From"] = "cgg-cancer@gu.se"  # TODO Get from config
-    msg["To"] = (
-        "gms_btb@gu.se, su.vokliniskgen.wgsadmin@vgregion.se, susanne.fransson@vgregion.se, hanna.engqvist@vgregion.se, nadiya.kazachkova@vgregion.se"  # TODO Get from config and have different recipients for errors and success
-    )
-    msg["Cc"] = "cgg-cancer@gu.se"  # TODO Get from config
+    msg["From"] = sender
+    msg["To"] = success_recipients 
+    msg["Cc"] = sender
 
     # Send the message
-    s = smtplib.SMTP("smtp.gu.se")
+    s = smtplib.SMTP(smtp)
     s.send_message(msg)
     s.quit()
-
 
 def send_email_qc(subject, body):
     """Send a simple email."""
@@ -32,12 +38,12 @@ def send_email_qc(subject, body):
     msg.set_content(body)
 
     msg["Subject"] = subject
-    msg["From"] = "cgg-cancer@gu.se"  # TODO Get from config
-    msg["Cc"] = "cgg-cancer@gu.se"
-    msg["To"] = "su.vokliniskgen.wgsadmin@vgregion.se"
+    msg["From"] = sender 
+    msg["To"] = qc_recipients 
+    msg["Cc"] = sender 
 
     # Send the message
-    s = smtplib.SMTP("smtp.gu.se")
+    s = smtplib.SMTP(smtp)
     s.send_message(msg)
     s.quit()
 
@@ -48,7 +54,7 @@ def start_email(run_name, samples):
     subject = f"WGS Somatic start mail {run_name}"
 
     body = f"""Starting wgs_somatic for the following samples in run {run_name}:\n
-{new_line.join(samples)}\n
+{"\n".join(samples)}\n
 You will get an email when the results are ready.\n
 Best regards,
 CGG Cancer
@@ -63,7 +69,7 @@ def end_email(run_name, samples):
     subject = f"WGS Somatic end mail {run_name}"
 
     body = f"""WGS somatic has finished successfully for the following samples in run {run_name}:\n
-{new_line.join(samples)}\n
+{"\n".join(samples)}\n
 Best regards,
 CGG Cancer
 """

--- a/tools/wgs_admin_summary/combine_wgsadmin_qc_summary.py
+++ b/tools/wgs_admin_summary/combine_wgsadmin_qc_summary.py
@@ -73,11 +73,10 @@ def combine_qc_stats(launcher_config, outputdirs, runname=None, qc_summary_direc
     logger.info("Starting WGS admin QC summary per run")
 
     # Prepare output directories and files
+    if devmode:
+        qc_summary_directory = config_data.get('wgsadmin_dev', os.getcwd())
     if qc_summary_directory is None:
-        if devmode:
-            qc_summary_directory = config_data.get('wgsadmin_dev', os.getcwd())
-        else:
-            qc_summary_directory = config_data.get('wgsadmin_dir', os.getcwd())
+        qc_summary_directory = config_data.get('wgsadmin_dir', os.getcwd())
     if runname:
         outputfile_prefix = os.path.join(qc_summary_directory, f"{runname}_wgs_somatic_qc_summary_{get_timestamp()}")
     else:

--- a/tools/wgs_admin_summary/combine_wgsadmin_qc_summary.py
+++ b/tools/wgs_admin_summary/combine_wgsadmin_qc_summary.py
@@ -56,6 +56,7 @@ def combine_qc_stats(launcher_config, outputdirs, runname=None, qc_summary_direc
     """
     Combine the first *_qc_stats_wgsadmin.xlsx file found in each output directory into a single summary Excel and TSV file.
     """
+    devmode = os.environ.get("DEVMODE") == "true"
     config_data = {}
     if launcher_config:
         try:
@@ -73,7 +74,10 @@ def combine_qc_stats(launcher_config, outputdirs, runname=None, qc_summary_direc
 
     # Prepare output directories and files
     if qc_summary_directory is None:
-        qc_summary_directory = config_data.get('wgsadmin_dir', os.getcwd())
+        if devmode:
+            qc_summary_directory = config_data.get('wgsadmin_dev', os.getcwd())
+        else:
+            qc_summary_directory = config_data.get('wgsadmin_dir', os.getcwd())
     if runname:
         outputfile_prefix = os.path.join(qc_summary_directory, f"{runname}_wgs_somatic_qc_summary_{get_timestamp()}")
     else:

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -64,6 +64,23 @@ def generate_context_objects(Rctx, logger):
     return Rctx
 
 
+def generate_develop_objects(config, run_type, logger):
+    """Create Rctx and Sctx for test samples"""
+
+    # Create a  fictiv run context
+    Rctx = RunContext(config['develop_mode']['runpath'])
+   
+    # TODO create different samples and runs for differeent tests and store in config
+    # Add samples for the test type you want
+    for sample_data in config["develop_mode"][run_type]["samples"]:
+        #sample_type = sample_data["type"] #This is not used now but fetched from slims?
+        Sctx = SampleContext(sample_data["sample"])
+        Sctx.add_fastq(sample_data["fastq_paths"])
+        Rctx.add_sample_context(Sctx)
+
+    return Rctx
+
+
 def return_first_new_run(config, instrument, logger):
     """Return first new run for given instrument, which has files for wgs_somatic analysis."""
     local_run_paths = look_for_runs(config, instrument)
@@ -182,11 +199,15 @@ def submit_pipeline(tumorsample, normalsample, outpath, config, logger, threads)
 
 def wrapper(instrument=None, outpath=None):
     '''Automatic wrapper function'''
-    
+    if os.environ.get("DEVMODE") == "true":
+        develop_mode = True
     # === Setup run ===
     try:
         config = read_config(WRAPPER_CONFIG_PATH)
-        wrapper_log_path = config["wrapper_log_path"]
+        if develop_mode:
+            wrapper_log_path = config["develop_mode"]["log_path"]
+        else:
+            wrapper_log_path = config["wrapper_log_path"]
         logger = setup_logger('wrapper', os.path.join(wrapper_log_path, f'{instrument}_WS_wrapper.log'))
 
         # Empty dict, will update later with T/N pair info
@@ -209,8 +230,19 @@ def wrapper(instrument=None, outpath=None):
                 logger.error('Output path for cron job not specified in the configuration.')
                 raise ValueError('Output path for cron job not specified in the configuration.')
 
+        # If develop mode
+        if develop_mode:
+            run_type = 'fail' #Test a failed or successfull run, for example
+            try:
+                outpath = config['develop_mode']['outpath']
+            except KeyError:
+                logger.error('Output path for develop_mode run not specified in the configuration.')
+                raise ValueError('Output path for develop_mode run not specified in the configuration.')
+            Rctx = generate_develop_objects(config, run_type, logger)
+
         # NOTE: we only process one run at a time. The next run will start upon the next cron execution
-        Rctx = return_first_new_run(config, instrument, logger)
+        else:
+            Rctx = return_first_new_run(config, instrument, logger)
 
         if Rctx is None:
             sys.exit(0)
@@ -280,7 +312,6 @@ def wrapper(instrument=None, outpath=None):
         print(f"Error during setup: {e}")
         error_setup_email(instrument)
         raise e
-
     # === Start analysis ===
     start_email(Rctx.run_name, final_pairs)
 
@@ -365,14 +396,19 @@ def manual(tumorsample=None, normalsample=None, outpath=None, copyresults=False,
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-i', '--instrument', help='For example novaseq_687_gc or novaseq_A01736', required=False)
-    parser.add_argument('-t','--tumorsample', help='Specify the name of the tumor sample (e.g. DNA123456)', required=False)
-    parser.add_argument('-n','--normalsample', help='Specify the name of the normal sample (e.g. DNA123456)', required=False)
+    parser.add_argument('-i', '--instrument', help='For example novaseq_687_gc or export DEVMODE=true', required=False)
+    parser.add_argument('-t', '--tumorsample', help='Specify the name of the tumor sample (e.g. DNA123456)', required=False)
+    parser.add_argument('-n', '--normalsample', help='Specify the name of the normal sample (e.g. DNA123456)', required=False)
     parser.add_argument('-o', '--outpath', help='Manually specify the path where the outputdir will go', required=False)
     parser.add_argument('-c', '--copyresults', help='Copy the results from a manual run to webstore', required=False, action='store_true', default=False)
     parser.add_argument('-q', '--qcsummary', help='Create combined qc summary for the run', required=False, action='store_true', default=False)
+    parser.add_argument('-d', '--develop_mode', help='Run wrapper in "develop mode"', required=False, action='store_true', default=False)
     args = parser.parse_args()
 
+    if args.develop_mode:
+        os.environ["DEVMODE"] = "true"
+        if not args.instrument:
+            args.instrument = "novaseq_A01736" #Temoprary solution to allow for instrument to be empty in devmode 
     if args.instrument:
         if args.tumorsample or args.normalsample or args.copyresults:
             parser.warning("When specifying --instrument, --tumorsample, --normalsample and --copyresults are ignored.")

--- a/wgs_somatic-run-wrapper.py
+++ b/wgs_somatic-run-wrapper.py
@@ -15,7 +15,7 @@ from definitions import WRAPPER_CONFIG_PATH, ROOT_DIR, LAUNCHER_CONFIG_PATH #, I
 from tools.context import RunContext, SampleContext
 from tools.helpers import setup_logger, read_config
 from tools.slims import get_sample_slims_info, find_or_download_fastqs, get_pair_dict, link_fastqs_to_outputdir
-from tools.custom_email import start_email, end_email, error_email, error_admin_qc_email, error_setup_email
+from tools.custom_email import start_email, end_email, error_email, error_admin_qc_email, error_setup_email, manual_start_email, manual_end_email
 from launch_snakemake import analysis_main, yearly_stats, copy_results, get_timestamp
 from tools.wgs_admin_summary.combine_wgsadmin_qc_summary import combine_qc_stats
 
@@ -199,13 +199,14 @@ def submit_pipeline(tumorsample, normalsample, outpath, config, logger, threads)
 
 def wrapper(instrument=None, outpath=None):
     '''Automatic wrapper function'''
-    if os.environ.get("DEVMODE") == "true":
-        develop_mode = True
+    devmode = os.environ.get("DEVMODE") == "true"
+
     # === Setup run ===
     try:
         config = read_config(WRAPPER_CONFIG_PATH)
-        if develop_mode:
+        if devmode:
             wrapper_log_path = config["develop_mode"]["log_path"]
+            outpath = config["develop_mode"]["outpath"]
         else:
             wrapper_log_path = config["wrapper_log_path"]
         logger = setup_logger('wrapper', os.path.join(wrapper_log_path, f'{instrument}_WS_wrapper.log'))
@@ -231,15 +232,9 @@ def wrapper(instrument=None, outpath=None):
                 raise ValueError('Output path for cron job not specified in the configuration.')
 
         # If develop mode
-        if develop_mode:
-            run_type = 'fail' #Test a failed or successfull run, for example
-            try:
-                outpath = config['develop_mode']['outpath']
-            except KeyError:
-                logger.error('Output path for develop_mode run not specified in the configuration.')
-                raise ValueError('Output path for develop_mode run not specified in the configuration.')
+        if devmode:
+            run_type = 'success' #For future testing of predefined run types, e.g., successfull, failed due to, quality, slims error, et.c.,
             Rctx = generate_develop_objects(config, run_type, logger)
-
         # NOTE: we only process one run at a time. The next run will start upon the next cron execution
         else:
             Rctx = return_first_new_run(config, instrument, logger)
@@ -312,6 +307,7 @@ def wrapper(instrument=None, outpath=None):
         print(f"Error during setup: {e}")
         error_setup_email(instrument)
         raise e
+
     # === Start analysis ===
     start_email(Rctx.run_name, final_pairs)
 
@@ -361,10 +357,17 @@ def wrapper(instrument=None, outpath=None):
         error_admin_qc_email(Rctx.run_name)
  
 
-def manual(tumorsample=None, normalsample=None, outpath=None, copyresults=False, qcsummary=False):
+def manual(tumorsample=None, normalsample=None, outpath=None, copyresults=False, qcsummary=False, email=False):
     '''Manual pipeline submission'''
+    devmode = os.environ.get("DEVMODE") == "true"
     config = read_config(WRAPPER_CONFIG_PATH)
-    wrapper_log_path = config["wrapper_log_path"]
+
+    if devmode:
+        wrapper_log_path = config["develop_mode"]["log_path"]
+        outpath = config["develop_mode"]["outpath"]
+    else:
+        wrapper_log_path = config["wrapper_log_path"]
+
     logger = setup_logger('wrapper', os.path.join(wrapper_log_path, 'Manual_WS_wrapper.log'))
 
     # If outputpath is not specified, get from config
@@ -376,33 +379,43 @@ def manual(tumorsample=None, normalsample=None, outpath=None, copyresults=False,
             raise ValueError('Output path for manual submission not specified in the configuration.')
 
     threads = []
-    outputdir = submit_pipeline(tumorsample, normalsample, outpath, config, logger, threads)
-    threads[0].start()  # For manual runs we only have one thread
+    
+    if email:
+        manual_start_email(tumorsample, normalsample)
 
+    outputdir = submit_pipeline(tumorsample, normalsample, outpath, config, logger, threads)
+
+    threads[0].start()  # For manual runs we only have one thread
     threads[0].join()  # Wait for the thread to finish
 
-    if copyresults and check_ok(outputdir):
-        copy_results(outputdir)
+    if check_ok(outputdir):
+        sucess_run = True
 
-    if qcsummary and check_ok(outputdir):
-        try:
-            logger.info(f'Combining qc stats for manual run with outputdir {outputdir}')
-            combine_qc_stats(launcher_config = LAUNCHER_CONFIG_PATH, outputdirs=[outputdir], runname='manual_run', logger=logger)
-            logger.info(f'Done with combining qc stats for manual run with outputdir {outputdir}')
-        except Exception as e:
-            logger.error(f"Error combining qc stats: {e}")
-    return
+        if copyresults:
+            copy_results(outputdir)
+
+        if qcsummary:
+            try:
+                logger.info(f'Combining qc stats for manual run with outputdir {outputdir}')
+                combine_qc_stats(launcher_config = LAUNCHER_CONFIG_PATH, outputdirs=[outputdir], runname='manual_run', logger=logger)
+                logger.info(f'Done with combining qc stats for manual run with outputdir {outputdir}')
+            except Exception as e:
+                logger.error(f"Error combining qc stats: {e}")
+
+    if email:
+        manual_end_email(sucess_run, tumorsample, normalsample)
 
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-i', '--instrument', help='For example novaseq_687_gc or export DEVMODE=true', required=False)
+    parser.add_argument('-i', '--instrument', help='For example novaseq_687_gc or novaseq_A01736', required=False)
     parser.add_argument('-t', '--tumorsample', help='Specify the name of the tumor sample (e.g. DNA123456)', required=False)
     parser.add_argument('-n', '--normalsample', help='Specify the name of the normal sample (e.g. DNA123456)', required=False)
     parser.add_argument('-o', '--outpath', help='Manually specify the path where the outputdir will go', required=False)
     parser.add_argument('-c', '--copyresults', help='Copy the results from a manual run to webstore', required=False, action='store_true', default=False)
     parser.add_argument('-q', '--qcsummary', help='Create combined qc summary for the run', required=False, action='store_true', default=False)
     parser.add_argument('-d', '--develop_mode', help='Run wrapper in "develop mode"', required=False, action='store_true', default=False)
+    parser.add_argument('-e', '--email', help='Send start, end and crash emails from a manual run', required=False, action='store_true', default=False)
     args = parser.parse_args()
 
     if args.develop_mode:
@@ -414,7 +427,7 @@ def main():
             parser.warning("When specifying --instrument, --tumorsample, --normalsample and --copyresults are ignored.")
         wrapper(args.instrument, args.outpath)
     elif args.tumorsample or args.normalsample:
-        manual(args.tumorsample, args.normalsample, args.outpath, args.copyresults, args.qcsummary)
+        manual(args.tumorsample, args.normalsample, args.outpath, args.copyresults, args.qcsummary, args.email)
     else:
         parser.error("You must specify either --instrument or --tumorsample/--normalsample.")
 


### PR DESCRIPTION
## Contents
Review deadline: null

Main reviewer: @octocat

### The What
- Added a development mode to the WGS Somatic wrapper.
- Moved hardcoded mail addresses to config files.
- Added wrapper flag to send email for manual runs
### The Why
- Development mode...
	- ensures no emails are going to clinicians or the lab.
	- makes it possible to run `wrapper`with non slims samples to test pipeline.
	- is set as a global variable and can be set in bash.rc so default behavior from user is to run in devmode.
- Instead of commenting out mailadress or other default behaviours, development mode simplifies implementations of test-specific parameters.
- Paths to data when testing is predefined instead of spreading data on the servers

- Email in manual mode was a request feature
### The How
- Added `--develop_mode` to `wgs_somatic-runwrapper.py`
- Added `mail_config.yaml` to `<path>/dependencies/configs/` in `<path>/exec/<path>` for routine configuration and in`<path>/dev/<path>` for development configuration.
- Added `--develop_mode` to `launch_snakemaker.py` for future compatibility
- Added `--email` to `wgs_somatic-runwrapper.py` for sending mail in manual mode

### This [[update](https://semver.org/)](https://semver.org/) is:

- [ ]  **MAJOR** - when you make incompatible API changes
- [x]  **MINOR** - when you add functionality in a backwards compatible manner
- [ ]  **PATCH** - when you make backwards compatible bug fixes or documentation/instructions

## Test Procedure
- Tested tumor-normal with wrapper, manual and standalone in default and develop mode
